### PR TITLE
Make release publication idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,4 +84,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag || github.ref_name }}
-        run: gh release create "$TAG" --generate-notes --verify-tag
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --target "$GITHUB_SHA" --title "$TAG"
+          else
+            gh release create "$TAG" --generate-notes --verify-tag
+          fi


### PR DESCRIPTION
Update the release workflow so rerunning a verified tag edits an existing release instead of failing when the release already exists.