### PR TITLE
Include modules and themes in coverage reporting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,10 @@ jobs:
         run: php artisan key:generate
 
       - name: Run tests with release coverage gate
-        run: php artisan test --coverage-clover=coverage.xml --min=100
+        run: composer test:coverage
+
+      - name: Generate expanded module and theme coverage
+        run: composer test:coverage:expanded
 
       - name: Install frontend dependencies
         run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,16 +59,19 @@ jobs:
       - name: Generate application key
         run: php artisan key:generate
 
-      # The threshold measures app/ alone — the host's five composition classes. Package
-      # coverage is each package's own gate, against its own phpunit.xml (§3.10).
+      # The host report includes app/, modules/, and themes/. Each package also keeps
+      # its standalone gate in the package repository.
       - name: Run tests
-        run: php artisan test --coverage-clover=coverage.xml --min=100
+        run: composer test:coverage
+
+      - name: Generate expanded module and theme coverage
+        run: composer test:coverage:expanded
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
+          files: ./coverage.xml,./coverage-expanded.xml
           disable_search: true
           flags: unittests
           name: codecov-umbrella

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Homestead.yaml
 Homestead.json
 /.vagrant
 .phpunit.result.cache
+coverage*.xml
 rr
 # .rr.yaml is tracked in git (needed for RoadRunner configuration)
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ vendor/bin/pest
 vendor/bin/pint --test
 vendor/bin/phpstan analyse --no-progress --memory-limit=512M
 XDEBUG_MODE=coverage php artisan test --coverage --min=100
+composer test:coverage:expanded
 npm audit
 npm run build
 ```

--- a/composer.json
+++ b/composer.json
@@ -198,7 +198,9 @@
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
         ],
-        "test": "vendor/bin/pest"
+        "test": "vendor/bin/pest",
+        "test:coverage": "XDEBUG_MODE=coverage php -d memory_limit=512M vendor/bin/pest --coverage-clover=coverage.xml --min=100",
+        "test:coverage:expanded": "XDEBUG_MODE=coverage php -d memory_limit=512M vendor/bin/pest --configuration=phpunit.coverage.xml --coverage-clover=coverage-expanded.xml"
     },
     "extra": {
         "laravel": {

--- a/phpunit.coverage.xml
+++ b/phpunit.coverage.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+        <testsuite name="Architecture">
+            <directory>tests/Architecture</directory>
+        </testsuite>
+    </testsuites>
+    <!-- Expanded coverage is uploaded for the host, tracked module source, and tracked theme source. -->
+    <source>
+        <include>
+            <directory>app</directory>
+            <directory>modules/activity-comments/src</directory>
+            <directory>modules/analytics-core/src</directory>
+            <directory>modules/analytics-google/src</directory>
+            <directory>modules/analytics-meta/src</directory>
+            <directory>modules/api-access/src</directory>
+            <directory>modules/application/src</directory>
+            <directory>modules/audit/src</directory>
+            <directory>modules/currency-context/src</directory>
+            <directory>modules/developer-experience/src</directory>
+            <directory>modules/feature-flags/src</directory>
+            <directory>modules/files-media/src</directory>
+            <directory>modules/identity-core/src</directory>
+            <directory>modules/identity-core-filament/src</directory>
+            <directory>modules/identity-socialstream/src</directory>
+            <directory>modules/import-export/src</directory>
+            <directory>modules/integrations/src</directory>
+            <directory>modules/jetstream-bridge/src</directory>
+            <directory>modules/localization-core/src</directory>
+            <directory>modules/localization-core-livewire/src</directory>
+            <directory>modules/localization-mymemory/src</directory>
+            <directory>modules/module-manager/src</directory>
+            <directory>modules/module-manager-filament/src</directory>
+            <directory>modules/notifications/src</directory>
+            <directory>modules/observability/src</directory>
+            <directory>modules/organizations-teams/src</directory>
+            <directory>modules/organizations-teams-filament/src</directory>
+            <directory>modules/profiles/src</directory>
+            <directory>modules/real-estate-core/src</directory>
+            <directory>modules/real-estate-core-api/src</directory>
+            <directory>modules/real-estate-core-filament/src</directory>
+            <directory>modules/real-estate-core-livewire/src</directory>
+            <directory>modules/real-estate-instructions/src</directory>
+            <directory>modules/real-estate-instructions-api/src</directory>
+            <directory>modules/real-estate-instructions-filament/src</directory>
+            <directory>modules/real-estate-instructions-livewire/src</directory>
+            <directory>modules/real-estate-listings/src</directory>
+            <directory>modules/real-estate-listings-api/src</directory>
+            <directory>modules/real-estate-listings-filament/src</directory>
+            <directory>modules/real-estate-listings-livewire/src</directory>
+            <directory>modules/real-estate-marketing/src</directory>
+            <directory>modules/real-estate-marketing-api/src</directory>
+            <directory>modules/real-estate-marketing-filament/src</directory>
+            <directory>modules/real-estate-marketing-livewire/src</directory>
+            <directory>modules/real-estate-matching/src</directory>
+            <directory>modules/real-estate-matching-api/src</directory>
+            <directory>modules/real-estate-matching-filament/src</directory>
+            <directory>modules/real-estate-matching-livewire/src</directory>
+            <directory>modules/real-estate-media-and-documents/src</directory>
+            <directory>modules/real-estate-media-and-documents-api/src</directory>
+            <directory>modules/real-estate-media-and-documents-filament/src</directory>
+            <directory>modules/real-estate-media-and-documents-livewire/src</directory>
+            <directory>modules/real-estate-offers/src</directory>
+            <directory>modules/real-estate-offers-api/src</directory>
+            <directory>modules/real-estate-offers-filament/src</directory>
+            <directory>modules/real-estate-offers-livewire/src</directory>
+            <directory>modules/real-estate-onthemarket/src</directory>
+            <directory>modules/real-estate-onthemarket-api/src</directory>
+            <directory>modules/real-estate-onthemarket-filament/src</directory>
+            <directory>modules/real-estate-onthemarket-livewire/src</directory>
+            <directory>modules/real-estate-parties/src</directory>
+            <directory>modules/real-estate-parties-api/src</directory>
+            <directory>modules/real-estate-parties-filament/src</directory>
+            <directory>modules/real-estate-parties-livewire/src</directory>
+            <directory>modules/real-estate-portals-reporting/src</directory>
+            <directory>modules/real-estate-portals-reporting-api/src</directory>
+            <directory>modules/real-estate-portals-reporting-filament/src</directory>
+            <directory>modules/real-estate-portals-reporting-livewire/src</directory>
+            <directory>modules/real-estate-properties/src</directory>
+            <directory>modules/real-estate-properties-api/src</directory>
+            <directory>modules/real-estate-properties-filament/src</directory>
+            <directory>modules/real-estate-properties-livewire/src</directory>
+            <directory>modules/real-estate-rightmove/src</directory>
+            <directory>modules/real-estate-rightmove-api/src</directory>
+            <directory>modules/real-estate-rightmove-filament/src</directory>
+            <directory>modules/real-estate-rightmove-livewire/src</directory>
+            <directory>modules/real-estate-sales-progression/src</directory>
+            <directory>modules/real-estate-sales-progression-api/src</directory>
+            <directory>modules/real-estate-sales-progression-filament/src</directory>
+            <directory>modules/real-estate-sales-progression-livewire/src</directory>
+            <directory>modules/real-estate-valuations/src</directory>
+            <directory>modules/real-estate-valuations-api/src</directory>
+            <directory>modules/real-estate-valuations-filament/src</directory>
+            <directory>modules/real-estate-valuations-livewire/src</directory>
+            <directory>modules/real-estate-viewings/src</directory>
+            <directory>modules/real-estate-viewings-api/src</directory>
+            <directory>modules/real-estate-viewings-filament/src</directory>
+            <directory>modules/real-estate-viewings-livewire/src</directory>
+            <directory>modules/real-estate-zoopla/src</directory>
+            <directory>modules/real-estate-zoopla-api/src</directory>
+            <directory>modules/real-estate-zoopla-filament/src</directory>
+            <directory>modules/real-estate-zoopla-livewire/src</directory>
+            <directory>modules/roles-permissions/src</directory>
+            <directory>modules/roles-permissions-filament/src</directory>
+            <directory>modules/scheduler-queues/src</directory>
+            <directory>modules/search/src</directory>
+            <directory>modules/search-api/src</directory>
+            <directory>modules/sessions-devices/src</directory>
+            <directory>modules/sessions-devices-filament/src</directory>
+            <directory>modules/settings/src</directory>
+            <directory>modules/settings-filament/src</directory>
+            <directory>modules/theme-support/src</directory>
+            <directory>modules/theme-support-livewire/src</directory>
+            <directory>modules/two-factor-authentication/src</directory>
+            <directory>modules/webhooks/src</directory>
+            <directory>themes/base/src</directory>
+            <directory>themes/clear-signal/src</directory>
+            <directory>themes/dark/src</directory>
+            <directory>themes/default/src</directory>
+            <directory>themes/real-estate-default/src</directory>
+        </include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:3xVFJ5tTr05dWL1gsJqF+UvWdv3X0Cz/CBaUG47hb3U="/>
+        <env name="APP_MAINTENANCE_DRIVER" value="file"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="BROADCAST_CONNECTION" value="null"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_URL" value=""/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="PULSE_ENABLED" value="false"/>
+        <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="NIGHTWATCH_ENABLED" value="false"/>
+    </php>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,9 +15,8 @@
             <directory>tests/Architecture</directory>
         </testsuite>
     </testsuites>
-    <!-- The host measures the host. Each package runs and measures itself, against its
-         own phpunit.xml and its own coverage threshold — a package's numbers are not
-         the composition's to report. -->
+    <!-- The application release gate is intentionally scoped to the host. The expanded
+         module/theme report is generated with phpunit.coverage.xml. -->
     <source>
         <include>
             <directory>app</directory>


### PR DESCRIPTION
## Summary
- keep the application 100% coverage gate explicit through `composer test:coverage`
- add `phpunit.coverage.xml` with every tracked module and theme `src/` directory
- generate and upload the expanded Clover report to Codecov
- make coverage commands explicit and memory-safe in Composer and CI
- validate the expanded PHPUnit configuration and document the command

## Verification
- `composer validate --strict`
- `vendor/bin/pint --test`
- `composer test:coverage`
- `composer test:coverage:expanded`
- expanded suite: 232 passed, 12 skipped, 827 assertions
