### PR TITLE
Complete letting and property management lifecycles

### DIFF
--- a/modules/real-estate-lettings-api/routes/api.php
+++ b/modules/real-estate-lettings-api/routes/api.php
@@ -8,4 +8,6 @@ Route::middleware('api')->prefix('api/real-estate/lettings')->group(function ():
     Route::post('/', [LettingController::class, 'store']);
     Route::get('/{letting}', [LettingController::class, 'show']);
     Route::patch('/{letting}', [LettingController::class, 'update']);
+    Route::patch('/{letting}/details', [LettingController::class, 'updateDetails']);
+    Route::post('/{letting}/failure', [LettingController::class, 'recordFailure']);
 });

--- a/modules/real-estate-lettings-api/src/Http/Controllers/LettingController.php
+++ b/modules/real-estate-lettings-api/src/Http/Controllers/LettingController.php
@@ -7,7 +7,9 @@ namespace Liberu\RealEstate\LettingsApi\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Liberu\RealEstate\Lettings\Application\CreateLetting;
+use Liberu\RealEstate\Lettings\Application\RecordLettingFailure;
 use Liberu\RealEstate\Lettings\Application\TransitionLetting;
+use Liberu\RealEstate\Lettings\Application\UpdateLettingDetails;
 use Liberu\RealEstate\Lettings\Domain\LettingStatus;
 use Liberu\RealEstate\Lettings\Models\Letting;
 
@@ -44,5 +46,23 @@ final class LettingController
         $data = $request->validate(['status' => 'required|string|in:draft,in_progress,completed,cancelled']);
 
         return response()->json(['data' => $transition->handle($letting, $user->current_team_id, $user->getAuthIdentifier(), LettingStatus::from($data['status']))]);
+    }
+
+    public function updateDetails(Request $request, Letting $letting, UpdateLettingDetails $update): JsonResponse
+    {
+        $user = $request->user();
+        abort_unless((string) $user?->current_team_id === (string) $letting->team_id, 404);
+        $data = $request->validate(['details' => 'required|array']);
+
+        return response()->json(['data' => $update->handle($letting, $user->current_team_id, $user->getAuthIdentifier(), $data['details'])]);
+    }
+
+    public function recordFailure(Request $request, Letting $letting, RecordLettingFailure $failure): JsonResponse
+    {
+        $user = $request->user();
+        abort_unless((string) $user?->current_team_id === (string) $letting->team_id, 404);
+        $data = $request->validate(['reason' => 'required|string|max:2000']);
+
+        return response()->json(['data' => $failure->handle($letting, $user->current_team_id, $user->getAuthIdentifier(), $data['reason'])]);
     }
 }

--- a/modules/real-estate-lettings-filament/src/Resources/LettingResource.php
+++ b/modules/real-estate-lettings-filament/src/Resources/LettingResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\RealEstate\LettingsFilament\Resources;
 
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
@@ -25,7 +26,7 @@ final class LettingResource extends Resource
 
     public static function form(Schema $schema): Schema
     {
-        return $schema->components([TextInput::make('subject')->required()->maxLength(255), Select::make('capability')->options(collect(LettingCapability::cases())->mapWithKeys(fn ($c) => [$c->value => str($c->value)->replace('_', ' ')->title()])->all())->required(), Select::make('status')->options(['draft' => 'Draft', 'in_progress' => 'In progress', 'completed' => 'Completed', 'cancelled' => 'Cancelled'])->required()]);
+        return $schema->components([TextInput::make('subject')->required()->maxLength(255), Select::make('capability')->options(collect(LettingCapability::cases())->mapWithKeys(fn ($c) => [$c->value => str($c->value)->replace('_', ' ')->title()])->all())->required(), Select::make('status')->options(['draft' => 'Draft', 'in_progress' => 'In progress', 'completed' => 'Completed', 'cancelled' => 'Cancelled'])->required(), Textarea::make('failure_reason')->maxLength(2000)->columnSpanFull()]);
     }
 
     public static function table(Table $table): Table

--- a/modules/real-estate-lettings/README.md
+++ b/modules/real-estate-lettings/README.md
@@ -1,3 +1,5 @@
 # Real Estate Lettings
 
 Team-scoped letting records with explicit lifecycle capabilities for applications, referencing, deposits, agreements, move-in/out, renewals, rent changes, and notices. Composer is unprefixed; the GitHub source repository uses `module-real-estate-lettings`.
+
+The implementation follows the [domain specification](https://github.com/liberusoftware/documentation/blob/main/projects/real-estate/features/lettings.md), [API specification](https://github.com/liberusoftware/documentation/blob/main/projects/real-estate/api/lettings.md), [Filament specification](https://github.com/liberusoftware/documentation/blob/main/projects/real-estate/filament/lettings.md), and [Livewire specification](https://github.com/liberusoftware/documentation/blob/main/projects/real-estate/livewire/lettings.md).

--- a/modules/real-estate-lettings/database/migrations/2026_08_23_000020_create_real_estate_lettings_table.php
+++ b/modules/real-estate-lettings/database/migrations/2026_08_23_000020_create_real_estate_lettings_table.php
@@ -21,6 +21,7 @@ return new class() extends Migration
             $table->string('status', 32)->index();
             $table->json('details')->nullable();
             $table->json('audit')->nullable();
+            $table->text('failure_reason')->nullable();
             $table->timestamp('completed_at')->nullable();
             $table->timestamp('cancelled_at')->nullable();
             $table->softDeletes();

--- a/modules/real-estate-lettings/src/Application/CreateLetting.php
+++ b/modules/real-estate-lettings/src/Application/CreateLetting.php
@@ -6,6 +6,7 @@ namespace Liberu\RealEstate\Lettings\Application;
 
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
+use Liberu\RealEstate\Lettings\Domain\Events\LettingCreated;
 use Liberu\RealEstate\Lettings\Domain\LettingCapability;
 use Liberu\RealEstate\Lettings\Domain\LettingStatus;
 use Liberu\RealEstate\Lettings\Models\Letting;
@@ -16,6 +17,7 @@ final class CreateLetting
     {
         $subject = trim((string) ($attributes['subject'] ?? ''));
         $capability = (string) ($attributes['capability'] ?? '');
+
         if ($subject === '') {
             throw ValidationException::withMessages(['subject' => 'A letting subject is required.']);
         }
@@ -23,6 +25,20 @@ final class CreateLetting
             throw ValidationException::withMessages(['capability' => 'Select a valid letting capability.']);
         }
 
-        return DB::transaction(fn (): Letting => Letting::query()->create(['team_id' => $teamId, 'created_by' => $actorId, 'property_id' => $attributes['property_id'] ?? null, 'party_id' => $attributes['party_id'] ?? null, 'subject' => $subject, 'capability' => $capability, 'status' => LettingStatus::Draft, 'details' => $attributes['details'] ?? [], 'audit' => [['event' => 'created', 'actor_id' => $actorId, 'at' => now()->toISOString()]]]));
+        $letting = DB::transaction(fn (): Letting => Letting::query()->create([
+            'team_id' => $teamId,
+            'created_by' => $actorId,
+            'property_id' => $attributes['property_id'] ?? null,
+            'party_id' => $attributes['party_id'] ?? null,
+            'subject' => $subject,
+            'capability' => $capability,
+            'status' => LettingStatus::Draft,
+            'details' => $attributes['details'] ?? [],
+            'audit' => [['event' => 'created', 'actor_id' => $actorId, 'at' => now()->toISOString()]],
+        ]));
+
+        event(new LettingCreated($letting, $actorId));
+
+        return $letting;
     }
 }

--- a/modules/real-estate-lettings/src/Application/RecordLettingFailure.php
+++ b/modules/real-estate-lettings/src/Application/RecordLettingFailure.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\Lettings\Application;
+
+use Illuminate\Validation\ValidationException;
+use Liberu\RealEstate\Lettings\Models\Letting;
+
+final class RecordLettingFailure
+{
+    public function handle(Letting $letting, int|string $teamId, int|string $actorId, string $reason): Letting
+    {
+        if ((string) $letting->team_id !== (string) $teamId) {
+            abort(404);
+        }
+        $reason = trim($reason);
+        if ($reason === '') {
+            throw ValidationException::withMessages(['reason' => 'A failure reason is required.']);
+        }
+        $letting->forceFill(['failure_reason' => $reason, 'audit' => [...($letting->audit ?? []), ['event' => 'failure_recorded', 'actor_id' => $actorId, 'reason' => $reason, 'at' => now()->toISOString()]]])->save();
+
+        return $letting->refresh();
+    }
+}

--- a/modules/real-estate-lettings/src/Application/TransitionLetting.php
+++ b/modules/real-estate-lettings/src/Application/TransitionLetting.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\RealEstate\Lettings\Application;
 
 use Illuminate\Validation\ValidationException;
+use Liberu\RealEstate\Lettings\Domain\Events\LettingStatusChanged;
 use Liberu\RealEstate\Lettings\Domain\LettingStatus;
 use Liberu\RealEstate\Lettings\Models\Letting;
 
@@ -18,7 +19,15 @@ final class TransitionLetting
         if ($letting->status === LettingStatus::Completed && $status !== LettingStatus::Completed) {
             throw ValidationException::withMessages(['status' => 'Completed lettings cannot be reopened.']);
         }
-        $letting->forceFill(['status' => $status, 'completed_at' => $status === LettingStatus::Completed ? now() : $letting->completed_at, 'cancelled_at' => $status === LettingStatus::Cancelled ? now() : $letting->cancelled_at, 'audit' => [...($letting->audit ?? []), ['event' => $status->value, 'actor_id' => $actorId, 'at' => now()->toISOString()]]])->save();
+
+        $from = $letting->status;
+        $letting->forceFill([
+            'status' => $status,
+            'completed_at' => $status === LettingStatus::Completed ? now() : $letting->completed_at,
+            'cancelled_at' => $status === LettingStatus::Cancelled ? now() : $letting->cancelled_at,
+            'audit' => [...($letting->audit ?? []), ['event' => $status->value, 'actor_id' => $actorId, 'at' => now()->toISOString()]],
+        ])->save();
+        event(new LettingStatusChanged($letting, $from, $status, $actorId));
 
         return $letting->refresh();
     }

--- a/modules/real-estate-lettings/src/Application/UpdateLettingDetails.php
+++ b/modules/real-estate-lettings/src/Application/UpdateLettingDetails.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\Lettings\Application;
+
+use Illuminate\Validation\ValidationException;
+use Liberu\RealEstate\Lettings\Domain\LettingCapability;
+use Liberu\RealEstate\Lettings\Domain\LettingCapabilityDefinition;
+use Liberu\RealEstate\Lettings\Models\Letting;
+
+final class UpdateLettingDetails
+{
+    public function handle(Letting $letting, int|string $teamId, int|string $actorId, array $details): Letting
+    {
+        if ((string) $letting->team_id !== (string) $teamId) {
+            abort(404);
+        }
+        $capability = LettingCapability::from((string) $letting->capability);
+        $required = LettingCapabilityDefinition::all()[$capability->value]['required'];
+        $missing = array_values(array_filter($required, fn (string $key): bool => ! array_key_exists($key, $details)));
+        if ($missing !== []) {
+            throw ValidationException::withMessages(['details' => 'Missing required capability data: '.implode(', ', $missing).'.']);
+        }
+        $letting->forceFill([
+            'details' => $details,
+            'audit' => [...($letting->audit ?? []), ['event' => 'details_updated', 'actor_id' => $actorId, 'at' => now()->toISOString()]],
+        ])->save();
+
+        return $letting->refresh();
+    }
+}

--- a/modules/real-estate-lettings/src/Domain/Events/LettingCreated.php
+++ b/modules/real-estate-lettings/src/Domain/Events/LettingCreated.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\Lettings\Domain\Events;
+
+use Liberu\RealEstate\Lettings\Models\Letting;
+
+final readonly class LettingCreated
+{
+    public function __construct(public Letting $letting, public int|string $actorId) {}
+}

--- a/modules/real-estate-lettings/src/Domain/Events/LettingStatusChanged.php
+++ b/modules/real-estate-lettings/src/Domain/Events/LettingStatusChanged.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\Lettings\Domain\Events;
+
+use Liberu\RealEstate\Lettings\Domain\LettingStatus;
+use Liberu\RealEstate\Lettings\Models\Letting;
+
+final readonly class LettingStatusChanged
+{
+    public function __construct(public Letting $letting, public LettingStatus $from, public LettingStatus $to, public int|string $actorId) {}
+}

--- a/modules/real-estate-lettings/src/Domain/LettingCapabilityDefinition.php
+++ b/modules/real-estate-lettings/src/Domain/LettingCapabilityDefinition.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\Lettings\Domain;
+
+final class LettingCapabilityDefinition
+{
+    /** @return array<string, array{label: string, required: array<int, string>}> */
+    public static function all(): array
+    {
+        return [
+            LettingCapability::Applications->value => ['label' => 'Applications', 'required' => ['applicant_id']],
+            LettingCapability::Referencing->value => ['label' => 'Referencing', 'required' => ['provider', 'outcome']],
+            LettingCapability::Deposits->value => ['label' => 'Deposits', 'required' => ['amount', 'scheme']],
+            LettingCapability::Agreements->value => ['label' => 'Agreements', 'required' => ['start_date', 'term_months']],
+            LettingCapability::MoveInOut->value => ['label' => 'Move-in/out', 'required' => ['inspection_date', 'inventory']],
+            LettingCapability::Renewals->value => ['label' => 'Renewals', 'required' => ['renewal_date']],
+            LettingCapability::RentChanges->value => ['label' => 'Rent changes', 'required' => ['effective_date', 'amount']],
+            LettingCapability::Notices->value => ['label' => 'Notices', 'required' => ['notice_type', 'served_at']],
+        ];
+    }
+}

--- a/modules/real-estate-lettings/src/LettingsServiceProvider.php
+++ b/modules/real-estate-lettings/src/LettingsServiceProvider.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace Liberu\RealEstate\Lettings;
 
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
+use Liberu\RealEstate\Lettings\Models\Letting;
+use Liberu\RealEstate\Lettings\Policies\LettingPolicy;
 
 final class LettingsServiceProvider extends ServiceProvider
 {
+    public function register(): void
+    {
+        Gate::policy(Letting::class, LettingPolicy::class);
+    }
+
     public function boot(): void
     {
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');

--- a/modules/real-estate-lettings/src/Policies/LettingPolicy.php
+++ b/modules/real-estate-lettings/src/Policies/LettingPolicy.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\Lettings\Policies;
+
+use Liberu\RealEstate\Lettings\Models\Letting;
+
+final class LettingPolicy
+{
+    public function view($user, Letting $letting): bool
+    {
+        return (string) $user?->current_team_id === (string) $letting->team_id;
+    }
+
+    public function update($user, Letting $letting): bool
+    {
+        return $this->view($user, $letting);
+    }
+
+    public function delete($user, Letting $letting): bool
+    {
+        return $this->view($user, $letting);
+    }
+}

--- a/modules/real-estate-lettings/src/Queries/ListLettings.php
+++ b/modules/real-estate-lettings/src/Queries/ListLettings.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\Lettings\Queries;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Liberu\RealEstate\Lettings\Models\Letting;
+
+final class ListLettings
+{
+    public function handle(int|string $teamId, ?string $capability = null, int $perPage = 25): LengthAwarePaginator
+    {
+        return Letting::query()->forTeam($teamId)->when($capability !== null, fn ($query) => $query->where('capability', $capability))->latest()->paginate(max(1, min($perPage, 100)));
+    }
+}

--- a/modules/real-estate-property-management-api/routes/api.php
+++ b/modules/real-estate-property-management-api/routes/api.php
@@ -8,4 +8,6 @@ Route::middleware('api')->prefix('api/real-estate/property-management')->group(f
     Route::post('/', [ManagementRecordController::class, 'store']);
     Route::get('/{record}', [ManagementRecordController::class, 'show']);
     Route::patch('/{record}', [ManagementRecordController::class, 'update']);
+    Route::patch('/{record}/details', [ManagementRecordController::class, 'updateDetails']);
+    Route::post('/{record}/failure', [ManagementRecordController::class, 'recordFailure']);
 });

--- a/modules/real-estate-property-management-api/src/Http/Controllers/ManagementRecordController.php
+++ b/modules/real-estate-property-management-api/src/Http/Controllers/ManagementRecordController.php
@@ -7,7 +7,9 @@ namespace Liberu\RealEstate\PropertyManagementApi\Http\Controllers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Liberu\RealEstate\PropertyManagement\Application\CreateManagementRecord;
+use Liberu\RealEstate\PropertyManagement\Application\RecordManagementFailure;
 use Liberu\RealEstate\PropertyManagement\Application\TransitionManagementRecord;
+use Liberu\RealEstate\PropertyManagement\Application\UpdateManagementDetails;
 use Liberu\RealEstate\PropertyManagement\Domain\ManagementStatus;
 use Liberu\RealEstate\PropertyManagement\Models\ManagementRecord;
 
@@ -44,5 +46,23 @@ final class ManagementRecordController
         $data = $request->validate(['status' => 'required|string|in:draft,in_progress,completed,cancelled']);
 
         return response()->json(['data' => $transition->handle($record, $user->current_team_id, $user->getAuthIdentifier(), ManagementStatus::from($data['status']))]);
+    }
+
+    public function updateDetails(Request $request, ManagementRecord $record, UpdateManagementDetails $update): JsonResponse
+    {
+        $user = $request->user();
+        abort_unless((string) $user?->current_team_id === (string) $record->team_id, 404);
+        $data = $request->validate(['details' => 'required|array']);
+
+        return response()->json(['data' => $update->handle($record, $user->current_team_id, $user->getAuthIdentifier(), $data['details'])]);
+    }
+
+    public function recordFailure(Request $request, ManagementRecord $record, RecordManagementFailure $failure): JsonResponse
+    {
+        $user = $request->user();
+        abort_unless((string) $user?->current_team_id === (string) $record->team_id, 404);
+        $data = $request->validate(['reason' => 'required|string|max:2000']);
+
+        return response()->json(['data' => $failure->handle($record, $user->current_team_id, $user->getAuthIdentifier(), $data['reason'])]);
     }
 }

--- a/modules/real-estate-property-management-filament/src/Resources/ManagementRecordResource.php
+++ b/modules/real-estate-property-management-filament/src/Resources/ManagementRecordResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\RealEstate\PropertyManagementFilament\Resources;
 
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
@@ -25,7 +26,7 @@ final class ManagementRecordResource extends Resource
 
     public static function form(Schema $schema): Schema
     {
-        return $schema->components([TextInput::make('subject')->required()->maxLength(255), Select::make('capability')->options(collect(ManagementCapability::cases())->mapWithKeys(fn ($c) => [$c->value => str($c->value)->replace('_', ' ')->title()])->all())->required(), Select::make('status')->options(['draft' => 'Draft', 'in_progress' => 'In progress', 'completed' => 'Completed', 'cancelled' => 'Cancelled'])->required()]);
+        return $schema->components([TextInput::make('subject')->required()->maxLength(255), Select::make('capability')->options(collect(ManagementCapability::cases())->mapWithKeys(fn ($c) => [$c->value => str($c->value)->replace('_', ' ')->title()])->all())->required(), Select::make('status')->options(['draft' => 'Draft', 'in_progress' => 'In progress', 'completed' => 'Completed', 'cancelled' => 'Cancelled'])->required(), Textarea::make('failure_reason')->maxLength(2000)->columnSpanFull()]);
     }
 
     public static function table(Table $table): Table

--- a/modules/real-estate-property-management/README.md
+++ b/modules/real-estate-property-management/README.md
@@ -1,3 +1,5 @@
 # Real Estate Property Management
 
 Team-scoped property management records with explicit lifecycle capabilities for rent schedules, statements, inspections, compliance, maintenance, contractors, and owner approvals. Composer is unprefixed; the GitHub source repository uses `module-real-estate-property-management`.
+
+The implementation follows the [domain specification](https://github.com/liberusoftware/documentation/blob/main/projects/real-estate/features/property-management.md), [API specification](https://github.com/liberusoftware/documentation/blob/main/projects/real-estate/api/property-management.md), [Filament specification](https://github.com/liberusoftware/documentation/blob/main/projects/real-estate/filament/property-management.md), and [Livewire specification](https://github.com/liberusoftware/documentation/blob/main/projects/real-estate/livewire/property-management.md).

--- a/modules/real-estate-property-management/database/migrations/2026_08_23_000021_create_property_management_records_table.php
+++ b/modules/real-estate-property-management/database/migrations/2026_08_23_000021_create_property_management_records_table.php
@@ -21,6 +21,7 @@ return new class() extends Migration
             $table->string('status', 32)->index();
             $table->json('details')->nullable();
             $table->json('audit')->nullable();
+            $table->text('failure_reason')->nullable();
             $table->timestamp('completed_at')->nullable();
             $table->timestamp('cancelled_at')->nullable();
             $table->softDeletes();

--- a/modules/real-estate-property-management/src/Application/CreateManagementRecord.php
+++ b/modules/real-estate-property-management/src/Application/CreateManagementRecord.php
@@ -6,6 +6,7 @@ namespace Liberu\RealEstate\PropertyManagement\Application;
 
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
+use Liberu\RealEstate\PropertyManagement\Domain\Events\ManagementRecordCreated;
 use Liberu\RealEstate\PropertyManagement\Domain\ManagementCapability;
 use Liberu\RealEstate\PropertyManagement\Domain\ManagementStatus;
 use Liberu\RealEstate\PropertyManagement\Models\ManagementRecord;
@@ -23,6 +24,20 @@ final class CreateManagementRecord
             throw ValidationException::withMessages(['capability' => 'Select a valid management capability.']);
         }
 
-        return DB::transaction(fn (): ManagementRecord => ManagementRecord::query()->create(['team_id' => $teamId, 'created_by' => $actorId, 'property_id' => $attributes['property_id'] ?? null, 'party_id' => $attributes['party_id'] ?? null, 'subject' => $subject, 'capability' => $capability, 'status' => ManagementStatus::Draft, 'details' => $attributes['details'] ?? [], 'audit' => [['event' => 'created', 'actor_id' => $actorId, 'at' => now()->toISOString()]]]));
+        $record = DB::transaction(fn (): ManagementRecord => ManagementRecord::query()->create([
+            'team_id' => $teamId,
+            'created_by' => $actorId,
+            'property_id' => $attributes['property_id'] ?? null,
+            'party_id' => $attributes['party_id'] ?? null,
+            'subject' => $subject,
+            'capability' => $capability,
+            'status' => ManagementStatus::Draft,
+            'details' => $attributes['details'] ?? [],
+            'audit' => [['event' => 'created', 'actor_id' => $actorId, 'at' => now()->toISOString()]],
+        ]));
+
+        event(new ManagementRecordCreated($record, $actorId));
+
+        return $record;
     }
 }

--- a/modules/real-estate-property-management/src/Application/RecordManagementFailure.php
+++ b/modules/real-estate-property-management/src/Application/RecordManagementFailure.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertyManagement\Application;
+
+use Illuminate\Validation\ValidationException;
+use Liberu\RealEstate\PropertyManagement\Models\ManagementRecord;
+
+final class RecordManagementFailure
+{
+    public function handle(ManagementRecord $record, int|string $teamId, int|string $actorId, string $reason): ManagementRecord
+    {
+        if ((string) $record->team_id !== (string) $teamId) {
+            abort(404);
+        }
+        $reason = trim($reason);
+        if ($reason === '') {
+            throw ValidationException::withMessages(['reason' => 'A failure reason is required.']);
+        }
+        $record->forceFill(['failure_reason' => $reason, 'audit' => [...($record->audit ?? []), ['event' => 'failure_recorded', 'actor_id' => $actorId, 'reason' => $reason, 'at' => now()->toISOString()]]])->save();
+
+        return $record->refresh();
+    }
+}

--- a/modules/real-estate-property-management/src/Application/TransitionManagementRecord.php
+++ b/modules/real-estate-property-management/src/Application/TransitionManagementRecord.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\RealEstate\PropertyManagement\Application;
 
 use Illuminate\Validation\ValidationException;
+use Liberu\RealEstate\PropertyManagement\Domain\Events\ManagementRecordStatusChanged;
 use Liberu\RealEstate\PropertyManagement\Domain\ManagementStatus;
 use Liberu\RealEstate\PropertyManagement\Models\ManagementRecord;
 
@@ -18,7 +19,15 @@ final class TransitionManagementRecord
         if ($record->status === ManagementStatus::Completed && $status !== ManagementStatus::Completed) {
             throw ValidationException::withMessages(['status' => 'Completed records cannot be reopened.']);
         }
-        $record->forceFill(['status' => $status, 'completed_at' => $status === ManagementStatus::Completed ? now() : $record->completed_at, 'cancelled_at' => $status === ManagementStatus::Cancelled ? now() : $record->cancelled_at, 'audit' => [...($record->audit ?? []), ['event' => $status->value, 'actor_id' => $actorId, 'at' => now()->toISOString()]]])->save();
+
+        $from = $record->status;
+        $record->forceFill([
+            'status' => $status,
+            'completed_at' => $status === ManagementStatus::Completed ? now() : $record->completed_at,
+            'cancelled_at' => $status === ManagementStatus::Cancelled ? now() : $record->cancelled_at,
+            'audit' => [...($record->audit ?? []), ['event' => $status->value, 'actor_id' => $actorId, 'at' => now()->toISOString()]],
+        ])->save();
+        event(new ManagementRecordStatusChanged($record, $from, $status, $actorId));
 
         return $record->refresh();
     }

--- a/modules/real-estate-property-management/src/Application/UpdateManagementDetails.php
+++ b/modules/real-estate-property-management/src/Application/UpdateManagementDetails.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertyManagement\Application;
+
+use Illuminate\Validation\ValidationException;
+use Liberu\RealEstate\PropertyManagement\Domain\ManagementCapability;
+use Liberu\RealEstate\PropertyManagement\Domain\ManagementCapabilityDefinition;
+use Liberu\RealEstate\PropertyManagement\Models\ManagementRecord;
+
+final class UpdateManagementDetails
+{
+    public function handle(ManagementRecord $record, int|string $teamId, int|string $actorId, array $details): ManagementRecord
+    {
+        if ((string) $record->team_id !== (string) $teamId) {
+            abort(404);
+        }
+        $capability = ManagementCapability::from((string) $record->capability);
+        $required = ManagementCapabilityDefinition::all()[$capability->value]['required'];
+        $missing = array_values(array_filter($required, fn (string $key): bool => ! array_key_exists($key, $details)));
+        if ($missing !== []) {
+            throw ValidationException::withMessages(['details' => 'Missing required capability data: '.implode(', ', $missing).'.']);
+        }
+        $record->forceFill([
+            'details' => $details,
+            'audit' => [...($record->audit ?? []), ['event' => 'details_updated', 'actor_id' => $actorId, 'at' => now()->toISOString()]],
+        ])->save();
+
+        return $record->refresh();
+    }
+}

--- a/modules/real-estate-property-management/src/Domain/Events/ManagementRecordCreated.php
+++ b/modules/real-estate-property-management/src/Domain/Events/ManagementRecordCreated.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertyManagement\Domain\Events;
+
+use Liberu\RealEstate\PropertyManagement\Models\ManagementRecord;
+
+final readonly class ManagementRecordCreated
+{
+    public function __construct(public ManagementRecord $record, public int|string $actorId) {}
+}

--- a/modules/real-estate-property-management/src/Domain/Events/ManagementRecordStatusChanged.php
+++ b/modules/real-estate-property-management/src/Domain/Events/ManagementRecordStatusChanged.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertyManagement\Domain\Events;
+
+use Liberu\RealEstate\PropertyManagement\Domain\ManagementStatus;
+use Liberu\RealEstate\PropertyManagement\Models\ManagementRecord;
+
+final readonly class ManagementRecordStatusChanged
+{
+    public function __construct(public ManagementRecord $record, public ManagementStatus $from, public ManagementStatus $to, public int|string $actorId) {}
+}

--- a/modules/real-estate-property-management/src/Domain/ManagementCapabilityDefinition.php
+++ b/modules/real-estate-property-management/src/Domain/ManagementCapabilityDefinition.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertyManagement\Domain;
+
+final class ManagementCapabilityDefinition
+{
+    /** @return array<string, array{label: string, required: array<int, string>}> */
+    public static function all(): array
+    {
+        return [
+            ManagementCapability::RentSchedule->value => ['label' => 'Rent schedule', 'required' => ['frequency', 'amount']],
+            ManagementCapability::Statements->value => ['label' => 'Statements', 'required' => ['period', 'entries']],
+            ManagementCapability::Inspections->value => ['label' => 'Inspections', 'required' => ['inspection_date', 'outcome']],
+            ManagementCapability::Compliance->value => ['label' => 'Compliance', 'required' => ['requirement', 'expires_at']],
+            ManagementCapability::Maintenance->value => ['label' => 'Maintenance', 'required' => ['description', 'priority']],
+            ManagementCapability::Contractors->value => ['label' => 'Contractors', 'required' => ['contractor_id', 'scope']],
+            ManagementCapability::OwnerApprovals->value => ['label' => 'Owner approvals', 'required' => ['decision', 'decided_at']],
+        ];
+    }
+}

--- a/modules/real-estate-property-management/src/Policies/ManagementRecordPolicy.php
+++ b/modules/real-estate-property-management/src/Policies/ManagementRecordPolicy.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertyManagement\Policies;
+
+use Liberu\RealEstate\PropertyManagement\Models\ManagementRecord;
+
+final class ManagementRecordPolicy
+{
+    public function view($user, ManagementRecord $record): bool
+    {
+        return (string) $user?->current_team_id === (string) $record->team_id;
+    }
+
+    public function update($user, ManagementRecord $record): bool
+    {
+        return $this->view($user, $record);
+    }
+
+    public function delete($user, ManagementRecord $record): bool
+    {
+        return $this->view($user, $record);
+    }
+}

--- a/modules/real-estate-property-management/src/PropertyManagementServiceProvider.php
+++ b/modules/real-estate-property-management/src/PropertyManagementServiceProvider.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace Liberu\RealEstate\PropertyManagement;
 
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
+use Liberu\RealEstate\PropertyManagement\Models\ManagementRecord;
+use Liberu\RealEstate\PropertyManagement\Policies\ManagementRecordPolicy;
 
 final class PropertyManagementServiceProvider extends ServiceProvider
 {
+    public function register(): void
+    {
+        Gate::policy(ManagementRecord::class, ManagementRecordPolicy::class);
+    }
+
     public function boot(): void
     {
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');

--- a/modules/real-estate-property-management/src/Queries/ListManagementRecords.php
+++ b/modules/real-estate-property-management/src/Queries/ListManagementRecords.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertyManagement\Queries;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Liberu\RealEstate\PropertyManagement\Models\ManagementRecord;
+
+final class ListManagementRecords
+{
+    public function handle(int|string $teamId, ?string $capability = null, int $perPage = 25): LengthAwarePaginator
+    {
+        return ManagementRecord::query()->forTeam($teamId)->when($capability !== null, fn ($query) => $query->where('capability', $capability))->latest()->paginate(max(1, min($perPage, 100)));
+    }
+}

--- a/tests/Feature/RealEstateLettingsLifecycleTest.php
+++ b/tests/Feature/RealEstateLettingsLifecycleTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Validation\ValidationException;
+use Liberu\RealEstate\Lettings\Application\CreateLetting;
+use Liberu\RealEstate\Lettings\Application\RecordLettingFailure;
+use Liberu\RealEstate\Lettings\Application\TransitionLetting;
+use Liberu\RealEstate\Lettings\Application\UpdateLettingDetails;
+use Liberu\RealEstate\Lettings\Domain\Events\LettingCreated;
+use Liberu\RealEstate\Lettings\Domain\Events\LettingStatusChanged;
+use Liberu\RealEstate\Lettings\Domain\LettingCapability;
+use Liberu\RealEstate\Lettings\Domain\LettingStatus;
+use Liberu\RealEstate\Lettings\Models\Letting;
+
+uses(RefreshDatabase::class);
+
+it('supports every letting capability through its validated public boundary', function (): void {
+    expect(LettingCapability::cases())->toHaveCount(8);
+
+    $letting = app(CreateLetting::class)->handle(1, 5, ['subject' => 'Application', 'capability' => LettingCapability::Applications->value]);
+    expect($letting->status)->toBe(LettingStatus::Draft);
+
+    expect(fn () => app(UpdateLettingDetails::class)->handle($letting, 1, 5, []))->toThrow(ValidationException::class);
+    $updated = app(UpdateLettingDetails::class)->handle($letting, 1, 5, ['applicant_id' => 12]);
+    expect($updated->details['applicant_id'])->toBe(12);
+});
+
+it('emits lifecycle events, records failure recovery evidence, and isolates teams', function (): void {
+    Event::fake();
+    $letting = app(CreateLetting::class)->handle(1, 5, ['subject' => 'Renewal', 'capability' => LettingCapability::Renewals->value, 'details' => ['renewal_date' => '2027-01-01']]);
+    app(TransitionLetting::class)->handle($letting, 1, 5, LettingStatus::Completed);
+    app(RecordLettingFailure::class)->handle($letting->refresh(), 1, 5, 'Provider timeout');
+
+    Event::assertDispatched(LettingCreated::class);
+    Event::assertDispatched(LettingStatusChanged::class);
+    expect($letting->refresh()->failure_reason)->toBe('Provider timeout')->and($letting->audit)->toHaveCount(3);
+    expect(Letting::query()->forTeam(2)->count())->toBe(0);
+});

--- a/tests/Feature/RealEstatePropertyManagementLifecycleTest.php
+++ b/tests/Feature/RealEstatePropertyManagementLifecycleTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Validation\ValidationException;
+use Liberu\RealEstate\PropertyManagement\Application\CreateManagementRecord;
+use Liberu\RealEstate\PropertyManagement\Application\RecordManagementFailure;
+use Liberu\RealEstate\PropertyManagement\Application\TransitionManagementRecord;
+use Liberu\RealEstate\PropertyManagement\Application\UpdateManagementDetails;
+use Liberu\RealEstate\PropertyManagement\Domain\Events\ManagementRecordCreated;
+use Liberu\RealEstate\PropertyManagement\Domain\Events\ManagementRecordStatusChanged;
+use Liberu\RealEstate\PropertyManagement\Domain\ManagementCapability;
+use Liberu\RealEstate\PropertyManagement\Domain\ManagementStatus;
+use Liberu\RealEstate\PropertyManagement\Models\ManagementRecord;
+
+uses(RefreshDatabase::class);
+
+it('supports every property management capability through its validated public boundary', function (): void {
+    expect(ManagementCapability::cases())->toHaveCount(7);
+
+    $record = app(CreateManagementRecord::class)->handle(1, 5, ['subject' => 'Rent schedule', 'capability' => ManagementCapability::RentSchedule->value]);
+    expect(fn () => app(UpdateManagementDetails::class)->handle($record, 1, 5, []))->toThrow(ValidationException::class);
+    $updated = app(UpdateManagementDetails::class)->handle($record, 1, 5, ['frequency' => 'monthly', 'amount' => 1500]);
+    expect($updated->details['amount'])->toBe(1500);
+});
+
+it('emits lifecycle events, records failures, and keeps records tenant-scoped', function (): void {
+    Event::fake();
+    $record = app(CreateManagementRecord::class)->handle(1, 5, ['subject' => 'Maintenance', 'capability' => ManagementCapability::Maintenance->value, 'details' => ['description' => 'Boiler repair', 'priority' => 'high']]);
+    app(TransitionManagementRecord::class)->handle($record, 1, 5, ManagementStatus::Completed);
+    app(RecordManagementFailure::class)->handle($record->refresh(), 1, 5, 'Contractor unavailable');
+
+    Event::assertDispatched(ManagementRecordCreated::class);
+    Event::assertDispatched(ManagementRecordStatusChanged::class);
+    expect($record->refresh()->failure_reason)->toBe('Contractor unavailable')->and($record->audit)->toHaveCount(3);
+    expect(ManagementRecord::query()->forTeam(2)->count())->toBe(0);
+});


### PR DESCRIPTION
## Summary
- add capability definitions and required data contracts for all Lettings and Property Management features
- add tenant policies, public queries, lifecycle events, failure recording, and audited detail mutations
- expose detail mutation and failure-recovery API endpoints
- expand Filament forms and add focused feature tests
- synchronize package sources under the required `module-` GitHub repositories and Packagist package names

## Documentation
- https://github.com/liberusoftware/real-estate-laravel/issues/1284
- https://github.com/liberusoftware/real-estate-laravel/issues/1293
- https://github.com/liberusoftware/documentation/tree/main/projects/real-estate

## Verification
- `vendor/bin/pint --test` on all changed package code
- focused lifecycle tests: 4 passed, 17 assertions
