### PR TITLE
Preserve legacy property listing filters

### DIFF
--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -30,6 +30,8 @@ final class PropertyController
         $pageSize = max(1, min($request->integer('page_size', 25), 100));
         $filters = $request->validate([
             'search' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'postal_code' => ['sometimes', 'nullable', 'string', 'max:20'],
+            'needs_syncing' => ['sometimes', 'boolean'],
             'branch_id' => ['sometimes', 'nullable', 'integer', Rule::exists('real_estate_branches', 'id')->where('team_id', $teamId)],
             'min_price' => ['sometimes', 'nullable', 'numeric', 'min:0'],
             'max_price' => ['sometimes', 'nullable', 'numeric', 'min:0', 'gte:min_price'],
@@ -51,6 +53,8 @@ final class PropertyController
 
         $query = Property::query()->forTeam($teamId)
             ->search($filters['search'] ?? null)
+            ->postalCode($filters['postal_code'] ?? null)
+            ->when($filters['needs_syncing'] ?? false, fn ($query) => $query->needsSyncing())
             ->when(array_key_exists('branch_id', $filters), fn ($query) => $query->where('branch_id', $filters['branch_id']))
             ->priceRange($filters['min_price'] ?? null, $filters['max_price'] ?? null)
             ->bedrooms($filters['min_bedrooms'] ?? null, $filters['max_bedrooms'] ?? null)
@@ -110,6 +114,7 @@ final class PropertyController
             'floor_plan_data' => ['sometimes', 'array'],
             'list_date' => ['sometimes', 'nullable', 'date'],
             'sold_date' => ['sometimes', 'nullable', 'date', 'after_or_equal:list_date'],
+            'last_synced_at' => ['sometimes', 'nullable', 'date'],
             'is_featured' => ['sometimes', 'boolean'],
             'live_tour_available' => ['sometimes', 'boolean'],
             'ar_tour_enabled' => ['sometimes', 'boolean'],
@@ -191,6 +196,7 @@ final class PropertyController
             'floor_plan_data' => ['sometimes', 'array'],
             'list_date' => ['sometimes', 'nullable', 'date'],
             'sold_date' => ['sometimes', 'nullable', 'date', 'after_or_equal:list_date'],
+            'last_synced_at' => ['sometimes', 'nullable', 'date'],
             'is_featured' => ['sometimes', 'boolean'],
             'live_tour_available' => ['sometimes', 'boolean'],
             'ar_tour_enabled' => ['sometimes', 'boolean'],

--- a/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
@@ -3,6 +3,8 @@
         <div wire:loading class="text-sm text-gray-500" role="status">Loading properties…</div>
         <label for="advanced-property-search">Search</label>
         <input id="advanced-property-search" type="search" wire:model.live="search" autocomplete="off">
+        <label for="advanced-postal-code">Postal code</label>
+        <input id="advanced-postal-code" type="text" wire:model="postalCode" maxlength="20" autocomplete="postal-code">
         <label for="advanced-min-price">Minimum price</label>
         <input id="advanced-min-price" type="number" wire:model="minPrice" min="0">
         <label for="advanced-max-price">Maximum price</label>
@@ -14,6 +16,10 @@
         <label for="advanced-featured">
             <input id="advanced-featured" type="checkbox" wire:model="featuredOnly">
             Featured only
+        </label>
+        <label for="advanced-needs-syncing">
+            <input id="advanced-needs-syncing" type="checkbox" wire:model="needsSyncingOnly">
+            Needs syncing
         </label>
         <button type="submit">Apply filters</button>
     </form>

--- a/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
@@ -2,6 +2,12 @@
     <div wire:loading class="text-sm text-gray-500" role="status">Loading properties…</div>
     <label for="property-search">Search properties</label>
     <input id="property-search" type="search" wire:model.live="search" autocomplete="off">
+    <label for="property-postal-code">Postal code</label>
+    <input id="property-postal-code" type="text" wire:model.live="postalCode" maxlength="20" autocomplete="postal-code">
+    <label for="needs-syncing-only">
+        <input id="needs-syncing-only" type="checkbox" wire:model.live="needsSyncingOnly">
+        Needs syncing
+    </label>
     @if ($error)
         <p role="alert">{{ $error }}</p>
     @endif

--- a/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
+++ b/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
@@ -17,6 +17,10 @@ final class AdvancedPropertySearch extends Component
     #[Validate('nullable|string|max:255')]
     public string $search = '';
 
+    public ?string $postalCode = null;
+
+    public bool $needsSyncingOnly = false;
+
     public ?float $minPrice = null;
 
     public ?float $maxPrice = null;
@@ -58,9 +62,11 @@ final class AdvancedPropertySearch extends Component
             'minArea' => ['nullable', 'numeric', 'min:0'],
             'maxArea' => ['nullable', 'numeric', 'min:0', 'gte:minArea'],
             'propertyType' => ['nullable', 'string', 'max:40'],
+            'postalCode' => ['nullable', 'string', 'max:20'],
             'country' => ['nullable', 'string', 'size:2'],
             'energyRating' => ['nullable', 'string', 'max:10'],
             'featuredOnly' => ['boolean'],
+            'needsSyncingOnly' => ['boolean'],
         ]);
 
         $this->resetPage();
@@ -73,6 +79,8 @@ final class AdvancedPropertySearch extends Component
             ? Property::query()->whereRaw('1 = 0')->paginate(12)
             : Property::query()->forTeam($teamId)
                 ->search($this->search)
+                ->postalCode($this->postalCode)
+                ->when($this->needsSyncingOnly, fn ($query) => $query->needsSyncing())
                 ->priceRange($this->minPrice, $this->maxPrice)
                 ->bedrooms($this->minBedrooms, $this->maxBedrooms)
                 ->bathrooms($this->minBathrooms, $this->maxBathrooms)

--- a/modules/real-estate-properties-livewire/src/Components/PropertyList.php
+++ b/modules/real-estate-properties-livewire/src/Components/PropertyList.php
@@ -21,6 +21,10 @@ final class PropertyList extends Component
     #[Validate('nullable|string|max:255')]
     public string $search = '';
 
+    public ?string $postalCode = null;
+
+    public bool $needsSyncingOnly = false;
+
     public ?string $propertyType = null;
 
     public ?float $minPrice = null;
@@ -80,6 +84,8 @@ final class PropertyList extends Component
             ? collect()
             : Property::query()->forTeam($teamId)
                 ->search($this->search)
+                ->postalCode($this->postalCode)
+                ->when($this->needsSyncingOnly, fn ($query) => $query->needsSyncing())
                 ->priceRange($this->minPrice, $this->maxPrice)
                 ->bedrooms($this->minBedrooms, $this->maxBedrooms)
                 ->propertyType($this->propertyType)

--- a/modules/real-estate-properties/src/Application/CreateProperty.php
+++ b/modules/real-estate-properties/src/Application/CreateProperty.php
@@ -68,6 +68,7 @@ final class CreateProperty
                 'floor_plan_data' => $attributes['floor_plan_data'] ?? null,
                 'list_date' => $attributes['list_date'] ?? null,
                 'sold_date' => $attributes['sold_date'] ?? null,
+                'last_synced_at' => $attributes['last_synced_at'] ?? null,
                 'is_featured' => $attributes['is_featured'] ?? false,
                 'live_tour_available' => $attributes['live_tour_available'] ?? false,
                 'ar_tour_enabled' => $attributes['ar_tour_enabled'] ?? false,

--- a/modules/real-estate-properties/src/Application/UpdateProperty.php
+++ b/modules/real-estate-properties/src/Application/UpdateProperty.php
@@ -40,7 +40,7 @@ final class UpdateProperty
                 'transit_score', 'transit_description', 'bike_score', 'bike_description',
                 'walkability_updated_at',
                 'virtual_tour_url', 'virtual_tour_provider', 'model_3d_url', 'floor_plan_data', 'property_type',
-                'characteristics', 'utilities', 'features', 'list_date', 'sold_date', 'is_featured',
+                'characteristics', 'utilities', 'features', 'list_date', 'sold_date', 'last_synced_at', 'is_featured',
                 'live_tour_available', 'ar_tour_enabled', 'ar_tour_settings', 'ar_placement_guide',
                 'ar_model_scale', 'holographic_tour_url', 'holographic_provider', 'holographic_metadata',
                 'holographic_enabled', 'energy_rating_date', 'insurance_policy_id',

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -83,6 +83,21 @@ final class Property extends Model
         });
     }
 
+    public function scopePostalCode(Builder $query, ?string $postalCode): Builder
+    {
+        $postalCode = trim((string) $postalCode);
+
+        return $query->when($postalCode !== '', fn (Builder $query): Builder => $query->where('postal_code', 'like', $postalCode.'%'));
+    }
+
+    public function scopeNeedsSyncing(Builder $query): Builder
+    {
+        return $query->where(function (Builder $query): void {
+            $query->whereNull('last_synced_at')
+                ->orWhereColumn('updated_at', '>', 'last_synced_at');
+        });
+    }
+
     public function scopePriceRange(Builder $query, mixed $minimum, mixed $maximum): Builder
     {
         return $query->when($minimum !== null && $minimum !== '', fn (Builder $query): Builder => $query->where('price', '>=', $minimum))

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -121,6 +121,24 @@ it('provides reusable bounded listing filters for every presentation adapter', f
         ->and($results->first()->title)->toBe('Featured family home');
 });
 
+it('supports legacy postal-prefix and stale-sync listing filters', function () {
+    $stale = app(CreateProperty::class)->handle(10, 20, [
+        'address' => '1 High Street',
+        'postal_code' => 'SW1A 1AA',
+        'last_synced_at' => now()->subDay(),
+    ]);
+    $current = app(CreateProperty::class)->handle(10, 20, [
+        'address' => '2 High Street',
+        'postal_code' => 'SW1B 2BB',
+        'last_synced_at' => now()->addMinute(),
+    ]);
+
+    $results = Property::query()->forTeam(10)->postalCode('SW1A')->needsSyncing()->get();
+
+    expect($results->pluck('id')->all())->toBe([$stale->getKey()])
+        ->and(Property::query()->forTeam(10)->postalCode('SW1B')->needsSyncing()->count())->toBe(0);
+});
+
 it('requires explicit property lifecycle transitions and records status history', function () {
     $property = app(CreateProperty::class)->handle(10, 20, ['address' => '1 High Street']);
     $transition = app(TransitionProperty::class);


### PR DESCRIPTION
Continues the modular conformance work by carrying postal-prefix and stale-sync property queries into the core boundary, API filters, and Livewire search surfaces. The implementation is covered by feature and architecture tests, and synchronized to the standalone properties, properties-api, and properties-livewire repositories.