### PR TITLE
Carry legacy property tour behavior

### DIFF
--- a/modules/real-estate-properties-api/src/Http/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-api/src/Http/Resources/PropertyResource.php
@@ -12,6 +12,6 @@ final class PropertyResource extends JsonResource
     /** @return array<string, mixed> */
     public function toArray(Request $request): array
     {
-        return $this->resource->only(['id', 'team_id', 'branch_id', 'reference', 'address', 'status', 'property_type', 'bedrooms', 'bathrooms', 'price', 'area_sqft', 'service_charge', 'ground_rent', 'characteristics', 'utilities', 'features', 'structured_address', 'epc', 'floor_plan_data', 'latitude', 'longitude', 'last_synced_at', 'published_at', 'created_at', 'updated_at']);
+        return $this->resource->only(['id', 'team_id', 'branch_id', 'reference', 'address', 'status', 'property_type', 'bedrooms', 'bathrooms', 'price', 'area_sqft', 'service_charge', 'ground_rent', 'characteristics', 'utilities', 'features', 'structured_address', 'epc', 'floor_plan_data', 'latitude', 'longitude', 'last_synced_at', 'published_at', 'virtual_tour_url', 'virtual_tour_provider', 'model_3d_url', 'holographic_tour_url', 'holographic_provider', 'holographic_enabled', 'created_at', 'updated_at']);
     }
 }

--- a/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
@@ -71,11 +71,14 @@ final class PropertyResource extends Resource
             TextInput::make('transit_score')->numeric()->minValue(0)->maxValue(100),
             TextInput::make('bike_score')->numeric()->minValue(0)->maxValue(100),
             TextInput::make('virtual_tour_url')->url()->maxLength(2048),
+            TextInput::make('virtual_tour_provider')->maxLength(40),
             Toggle::make('live_tour_available'),
             TextInput::make('model_3d_url')->url()->maxLength(2048),
             Toggle::make('is_featured'),
             Toggle::make('ar_tour_enabled'),
             Toggle::make('holographic_enabled'),
+            TextInput::make('holographic_tour_url')->url()->maxLength(2048),
+            TextInput::make('holographic_provider')->maxLength(255),
         ]);
     }
 

--- a/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
@@ -25,6 +25,9 @@
         @forelse ($properties as $property)
             <li wire:key="property-{{ $property->getKey() }}">
                 {{ $property->address }} ({{ $property->status->value }})
+                @if ($property->hasVirtualTour())
+                    <span aria-label="Virtual tour available">Virtual tour</span>
+                @endif
                 @if ($property->status->value === 'draft')
                     <button type="button" wire:click="publish({{ $property->getKey() }})">Publish</button>
                 @elseif ($property->status->value === 'available')

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -98,6 +98,43 @@ final class Property extends Model
         });
     }
 
+    public function needsWalkabilityUpdate(): bool
+    {
+        return $this->walkability_updated_at === null
+            || $this->walkability_updated_at->lt(now()->subDays(30));
+    }
+
+    public function hasVirtualTour(): bool
+    {
+        return $this->virtualTourEmbed() !== null;
+    }
+
+    public function getVirtualTourEmbed(): ?string
+    {
+        return $this->virtualTourEmbed();
+    }
+
+    public function hasHolographicTour(): bool
+    {
+        return (bool) $this->holographic_enabled && filled($this->holographic_tour_url);
+    }
+
+    private function virtualTourEmbed(): ?string
+    {
+        $url = (string) $this->virtual_tour_url;
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+        $host = strtolower((string) parse_url($url, PHP_URL_HOST));
+        $allowedHosts = ['matterport.com', 'kuula.co', '3dvista.com', '3dv.st', 'seekbeak.com'];
+
+        if ($scheme !== 'https' || ! filter_var($url, FILTER_VALIDATE_URL) || ! collect($allowedHosts)->contains(
+            fn (string $allowed): bool => $host === $allowed || str_ends_with($host, '.'.$allowed)
+        )) {
+            return null;
+        }
+
+        return '<iframe width="100%" height="480" src="'.htmlspecialchars($url, ENT_QUOTES, 'UTF-8').'" frameborder="0" sandbox="allow-scripts allow-same-origin allow-presentation" referrerpolicy="no-referrer" allow="xr-spatial-tracking" allowfullscreen></iframe>';
+    }
+
     public function scopePriceRange(Builder $query, mixed $minimum, mixed $maximum): Builder
     {
         return $query->when($minimum !== null && $minimum !== '', fn (Builder $query): Builder => $query->where('price', '>=', $minimum))

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -139,6 +139,28 @@ it('supports legacy postal-prefix and stale-sync listing filters', function () {
         ->and(Property::query()->forTeam(10)->postalCode('SW1B')->needsSyncing()->count())->toBe(0);
 });
 
+it('validates legacy property tour helpers and walkability freshness', function () {
+    $property = app(CreateProperty::class)->handle(10, 20, [
+        'address' => '1 High Street',
+        'virtual_tour_url' => 'https://my.matterport.com/show/?m=abc',
+        'holographic_tour_url' => 'https://example.test/holographic',
+        'holographic_enabled' => true,
+    ]);
+
+    expect($property->hasVirtualTour())->toBeTrue()
+        ->and($property->getVirtualTourEmbed())->toContain('https://my.matterport.com/show/?m=abc')
+        ->and($property->hasHolographicTour())->toBeTrue()
+        ->and($property->needsWalkabilityUpdate())->toBeTrue();
+
+    $property->update([
+        'virtual_tour_url' => 'http://my.matterport.com/show/?m=unsafe',
+        'walkability_updated_at' => now(),
+    ]);
+
+    expect($property->fresh()->hasVirtualTour())->toBeFalse()
+        ->and($property->fresh()->needsWalkabilityUpdate())->toBeFalse();
+});
+
 it('requires explicit property lifecycle transitions and records status history', function () {
     $property = app(CreateProperty::class)->handle(10, 20, ['address' => '1 High Street']);
     $transition = app(TransitionProperty::class);


### PR DESCRIPTION
Carry provider-neutral legacy property behavior into the modular property boundary: validate virtual-tour embeds, expose walkability freshness and holographic-tour helpers, and surface tour metadata in API, Filament, and Livewire adapters. The matching standalone module repositories have been synchronized and merged.