### PR TITLE
Carry legacy active insurance behavior

### DIFF
--- a/modules/real-estate-properties-api/src/Http/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-api/src/Http/Resources/PropertyResource.php
@@ -12,6 +12,6 @@ final class PropertyResource extends JsonResource
     /** @return array<string, mixed> */
     public function toArray(Request $request): array
     {
-        return $this->resource->only(['id', 'team_id', 'branch_id', 'reference', 'address', 'status', 'property_type', 'bedrooms', 'bathrooms', 'price', 'area_sqft', 'service_charge', 'ground_rent', 'characteristics', 'utilities', 'features', 'structured_address', 'epc', 'floor_plan_data', 'latitude', 'longitude', 'last_synced_at', 'published_at', 'virtual_tour_url', 'virtual_tour_provider', 'model_3d_url', 'holographic_tour_url', 'holographic_provider', 'holographic_enabled', 'created_at', 'updated_at']) + ['is_hmo' => $this->resource->isHmo()];
+        return $this->resource->only(['id', 'team_id', 'branch_id', 'reference', 'address', 'status', 'property_type', 'bedrooms', 'bathrooms', 'price', 'area_sqft', 'service_charge', 'ground_rent', 'characteristics', 'utilities', 'features', 'structured_address', 'epc', 'floor_plan_data', 'latitude', 'longitude', 'last_synced_at', 'published_at', 'virtual_tour_url', 'virtual_tour_provider', 'model_3d_url', 'holographic_tour_url', 'holographic_provider', 'holographic_enabled', 'created_at', 'updated_at']) + ['is_hmo' => $this->resource->isHmo(), 'has_active_insurance' => $this->resource->hasActiveInsurance()];
     }
 }

--- a/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
@@ -87,6 +87,10 @@ final class PropertyResource extends Resource
             Toggle::make('holographic_enabled'),
             TextInput::make('holographic_tour_url')->url()->maxLength(2048),
             TextInput::make('holographic_provider')->maxLength(255),
+            TextInput::make('insurance_policy_id')->numeric()->minValue(1),
+            TextInput::make('insurance_coverage_amount')->numeric()->minValue(0),
+            TextInput::make('insurance_premium')->numeric()->minValue(0),
+            TextInput::make('insurance_expiry_date')->date(),
         ]);
     }
 

--- a/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
@@ -28,6 +28,9 @@
                 @if ($property->isHmo())
                     <span aria-label="House in multiple occupation">HMO</span>
                 @endif
+                @if ($property->hasActiveInsurance())
+                    <span aria-label="Active insurance">Insured</span>
+                @endif
                 @if ($property->hasVirtualTour())
                     <span aria-label="Virtual tour available">Virtual tour</span>
                 @endif

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -124,6 +124,13 @@ final class Property extends Model
         return strtolower((string) $this->property_type) === 'hmo';
     }
 
+    public function hasActiveInsurance(): bool
+    {
+        return filled($this->insurance_policy_id)
+            && $this->insurance_expiry_date !== null
+            && $this->insurance_expiry_date->isFuture();
+    }
+
     private function virtualTourEmbed(): ?string
     {
         $url = (string) $this->virtual_tour_url;

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -175,6 +175,20 @@ it('preserves the legacy HMO property helper across case variants', function () 
         ->and($house->isHmo())->toBeFalse();
 });
 
+it('preserves the legacy active insurance helper', function () {
+    $property = app(CreateProperty::class)->handle(10, 20, [
+        'address' => '1 High Street',
+        'insurance_policy_id' => 42,
+        'insurance_expiry_date' => now()->addDay(),
+    ]);
+
+    expect($property->hasActiveInsurance())->toBeTrue();
+
+    $property->update(['insurance_expiry_date' => now()->subDay()]);
+
+    expect($property->fresh()->hasActiveInsurance())->toBeFalse();
+});
+
 it('requires explicit property lifecycle transitions and records status history', function () {
     $property = app(CreateProperty::class)->handle(10, 20, ['address' => '1 High Street']);
     $transition = app(TransitionProperty::class);


### PR DESCRIPTION
## Summary
- restore the legacy active-insurance property helper
- expose active insurance state in the API resource
- add insurance fields to the Filament property form
- render an accessible insured marker in the Livewire list

## Verification
- vendor/bin/pint --test
- vendor/bin/pest
