### PR TITLE
Carry legacy nearby property search

### DIFF
--- a/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
+++ b/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
@@ -9,6 +9,10 @@ paths:
     get:
       operationId: real.estate.properties.list
       security: [{sanctum: []}]
+      parameters:
+        - {name: latitude, in: query, schema: {type: number, minimum: -90, maximum: 90}}
+        - {name: longitude, in: query, schema: {type: number, minimum: -180, maximum: 180}}
+        - {name: radius, in: query, schema: {type: number, exclusiveMinimum: 0, maximum: 500, description: Radius in kilometres}}
       responses:
         '200': {description: Authorized paginated properties}
     post:

--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -32,6 +32,9 @@ final class PropertyController
             'search' => ['sometimes', 'nullable', 'string', 'max:255'],
             'postal_code' => ['sometimes', 'nullable', 'string', 'max:20'],
             'needs_syncing' => ['sometimes', 'boolean'],
+            'latitude' => ['sometimes', 'nullable', 'numeric', 'between:-90,90'],
+            'longitude' => ['sometimes', 'nullable', 'numeric', 'between:-180,180'],
+            'radius' => ['sometimes', 'nullable', 'numeric', 'gt:0', 'max:500'],
             'branch_id' => ['sometimes', 'nullable', 'integer', Rule::exists('real_estate_branches', 'id')->where('team_id', $teamId)],
             'min_price' => ['sometimes', 'nullable', 'numeric', 'min:0'],
             'max_price' => ['sometimes', 'nullable', 'numeric', 'min:0', 'gte:min_price'],
@@ -55,6 +58,7 @@ final class PropertyController
             ->search($filters['search'] ?? null)
             ->postalCode($filters['postal_code'] ?? null)
             ->when($filters['needs_syncing'] ?? false, fn ($query) => $query->needsSyncing())
+            ->when($filters['latitude'] !== null && $filters['longitude'] !== null && $filters['radius'] !== null, fn ($query) => $query->nearby($filters['latitude'], $filters['longitude'], $filters['radius']))
             ->when(array_key_exists('branch_id', $filters), fn ($query) => $query->where('branch_id', $filters['branch_id']))
             ->priceRange($filters['min_price'] ?? null, $filters['max_price'] ?? null)
             ->bedrooms($filters['min_bedrooms'] ?? null, $filters['max_bedrooms'] ?? null)

--- a/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
@@ -13,6 +13,12 @@
         <input id="advanced-property-type" type="text" wire:model="propertyType" maxlength="40">
         <label for="advanced-country">Country</label>
         <input id="advanced-country" type="text" wire:model="country" maxlength="2">
+        <label for="advanced-latitude">Latitude</label>
+        <input id="advanced-latitude" type="number" wire:model="latitude" min="-90" max="90" step="any">
+        <label for="advanced-longitude">Longitude</label>
+        <input id="advanced-longitude" type="number" wire:model="longitude" min="-180" max="180" step="any">
+        <label for="advanced-radius">Radius (km)</label>
+        <input id="advanced-radius" type="number" wire:model="radius" min="0.1" max="500" step="any">
         <label for="advanced-featured">
             <input id="advanced-featured" type="checkbox" wire:model="featuredOnly">
             Featured only

--- a/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
+++ b/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
@@ -43,6 +43,12 @@ final class AdvancedPropertySearch extends Component
 
     public ?string $energyRating = null;
 
+    public ?float $latitude = null;
+
+    public ?float $longitude = null;
+
+    public ?float $radius = null;
+
     public bool $featuredOnly = false;
 
     public function updatedSearch(): void
@@ -65,6 +71,9 @@ final class AdvancedPropertySearch extends Component
             'postalCode' => ['nullable', 'string', 'max:20'],
             'country' => ['nullable', 'string', 'size:2'],
             'energyRating' => ['nullable', 'string', 'max:10'],
+            'latitude' => ['nullable', 'numeric', 'between:-90,90'],
+            'longitude' => ['nullable', 'numeric', 'between:-180,180'],
+            'radius' => ['nullable', 'numeric', 'gt:0', 'max:500'],
             'featuredOnly' => ['boolean'],
             'needsSyncingOnly' => ['boolean'],
         ]);
@@ -88,6 +97,7 @@ final class AdvancedPropertySearch extends Component
                 ->propertyType($this->propertyType)
                 ->country($this->country)
                 ->energyRating($this->energyRating)
+                ->when($this->latitude !== null && $this->longitude !== null && $this->radius !== null, fn ($query) => $query->nearby($this->latitude, $this->longitude, $this->radius))
                 ->when($this->featuredOnly, fn ($query) => $query->featured())
                 ->latest()->paginate(12);
 

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -90,6 +90,32 @@ final class Property extends Model
         return $query->when($postalCode !== '', fn (Builder $query): Builder => $query->where('postal_code', 'like', $postalCode.'%'));
     }
 
+    public function scopeNearby(Builder $query, float|int|string $latitude, float|int|string $longitude, float|int|string $radius): Builder
+    {
+        $latitude = (float) $latitude;
+        $longitude = (float) $longitude;
+        $radius = (float) $radius;
+
+        if ($latitude < -90 || $latitude > 90 || $longitude < -180 || $longitude > 180 || $radius <= 0) {
+            throw new \InvalidArgumentException('Nearby search coordinates and radius are invalid.');
+        }
+
+        $table = $query->getModel()->getTable();
+        $earthRadiusKilometers = 6371;
+        $latitudeLiteral = sprintf('%.8F', $latitude);
+        $longitudeLiteral = sprintf('%.8F', $longitude);
+        $radiusLiteral = sprintf('%.8F', $radius);
+        $distance = "($earthRadiusKilometers * acos(cos(radians($latitudeLiteral)) * cos(radians($table.latitude)) * cos(radians($table.longitude) - radians($longitudeLiteral)) + sin(radians($latitudeLiteral)) * sin(radians($table.latitude))))";
+
+        return $query
+            ->whereNotNull('latitude')
+            ->whereNotNull('longitude')
+            ->select($table.'.*')
+            ->selectRaw($distance.' as distance')
+            ->whereRaw($distance.' <= '.$radiusLiteral)
+            ->orderBy('distance');
+    }
+
     public function scopeNeedsSyncing(Builder $query): Builder
     {
         return $query->where(function (Builder $query): void {

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -139,6 +139,24 @@ it('supports legacy postal-prefix and stale-sync listing filters', function () {
         ->and(Property::query()->forTeam(10)->postalCode('SW1B')->needsSyncing()->count())->toBe(0);
 });
 
+it('supports legacy nearby-property searching in kilometres', function () {
+    $near = app(CreateProperty::class)->handle(10, 20, [
+        'address' => '1 High Street',
+        'latitude' => 51.5074,
+        'longitude' => -0.1278,
+    ]);
+    app(CreateProperty::class)->handle(10, 20, [
+        'address' => '2 Far Street',
+        'latitude' => 52.4862,
+        'longitude' => -1.8904,
+    ]);
+
+    $results = Property::query()->forTeam(10)->nearby(51.5074, -0.1278, 5)->get();
+
+    expect($results->pluck('id')->all())->toBe([$near->getKey()])
+        ->and($results->first()->distance)->toBeLessThan(0.01);
+});
+
 it('validates legacy property tour helpers and walkability freshness', function () {
     $property = app(CreateProperty::class)->handle(10, 20, [
         'address' => '1 High Street',


### PR DESCRIPTION
## Summary
- restore the legacy kilometer-radius nearby property scope
- expose validated latitude, longitude, and radius API filters
- add the same state and controls to Advanced Property Search
- document the query parameters in OpenAPI
- cover distance filtering and ordering

## Verification
- vendor/bin/pint --test
- vendor/bin/pest
