### PR TITLE
Carry legacy amenity filtering

### DIFF
--- a/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
+++ b/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
@@ -13,6 +13,7 @@ paths:
         - {name: latitude, in: query, schema: {type: number, minimum: -90, maximum: 90}}
         - {name: longitude, in: query, schema: {type: number, minimum: -180, maximum: 180}}
         - {name: radius, in: query, schema: {type: number, exclusiveMinimum: 0, maximum: 500, description: Radius in kilometres}}
+        - {name: amenities[], in: query, style: form, explode: true, schema: {type: array, maxItems: 20, items: {type: string, maxLength: 80}}}
       responses:
         '200': {description: Authorized paginated properties}
     post:

--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -32,6 +32,8 @@ final class PropertyController
             'search' => ['sometimes', 'nullable', 'string', 'max:255'],
             'postal_code' => ['sometimes', 'nullable', 'string', 'max:20'],
             'needs_syncing' => ['sometimes', 'boolean'],
+            'amenities' => ['sometimes', 'array', 'max:20'],
+            'amenities.*' => ['string', 'max:80'],
             'latitude' => ['sometimes', 'nullable', 'numeric', 'between:-90,90'],
             'longitude' => ['sometimes', 'nullable', 'numeric', 'between:-180,180'],
             'radius' => ['sometimes', 'nullable', 'numeric', 'gt:0', 'max:500'],
@@ -58,6 +60,7 @@ final class PropertyController
             ->search($filters['search'] ?? null)
             ->postalCode($filters['postal_code'] ?? null)
             ->when($filters['needs_syncing'] ?? false, fn ($query) => $query->needsSyncing())
+            ->hasAmenities($filters['amenities'] ?? [])
             ->when($filters['latitude'] !== null && $filters['longitude'] !== null && $filters['radius'] !== null, fn ($query) => $query->nearby($filters['latitude'], $filters['longitude'], $filters['radius']))
             ->when(array_key_exists('branch_id', $filters), fn ($query) => $query->where('branch_id', $filters['branch_id']))
             ->priceRange($filters['min_price'] ?? null, $filters['max_price'] ?? null)

--- a/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
@@ -10,6 +10,7 @@ use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
@@ -87,6 +88,7 @@ final class PropertyResource extends Resource
             Toggle::make('holographic_enabled'),
             TextInput::make('holographic_tour_url')->url()->maxLength(2048),
             TextInput::make('holographic_provider')->maxLength(255),
+            TagsInput::make('features')->separator(','),
             TextInput::make('insurance_policy_id')->numeric()->minValue(1),
             TextInput::make('insurance_coverage_amount')->numeric()->minValue(0),
             TextInput::make('insurance_premium')->numeric()->minValue(0),

--- a/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
@@ -19,6 +19,15 @@
         <input id="advanced-longitude" type="number" wire:model="longitude" min="-180" max="180" step="any">
         <label for="advanced-radius">Radius (km)</label>
         <input id="advanced-radius" type="number" wire:model="radius" min="0.1" max="500" step="any">
+        <fieldset>
+            <legend>Amenities</legend>
+            @foreach (['garden' => 'Garden', 'parking' => 'Parking', 'balcony' => 'Balcony', 'garage' => 'Garage', 'fireplace' => 'Fireplace'] as $amenity => $label)
+                <label for="advanced-amenity-{{ $amenity }}">
+                    <input id="advanced-amenity-{{ $amenity }}" type="checkbox" value="{{ $amenity }}" wire:model="selectedAmenities">
+                    {{ $label }}
+                </label>
+            @endforeach
+        </fieldset>
         <label for="advanced-featured">
             <input id="advanced-featured" type="checkbox" wire:model="featuredOnly">
             Featured only

--- a/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
+++ b/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
@@ -43,6 +43,9 @@ final class AdvancedPropertySearch extends Component
 
     public ?string $energyRating = null;
 
+    /** @var array<int, string> */
+    public array $selectedAmenities = [];
+
     public ?float $latitude = null;
 
     public ?float $longitude = null;
@@ -71,6 +74,8 @@ final class AdvancedPropertySearch extends Component
             'postalCode' => ['nullable', 'string', 'max:20'],
             'country' => ['nullable', 'string', 'size:2'],
             'energyRating' => ['nullable', 'string', 'max:10'],
+            'selectedAmenities' => ['array', 'max:20'],
+            'selectedAmenities.*' => ['string', 'max:80'],
             'latitude' => ['nullable', 'numeric', 'between:-90,90'],
             'longitude' => ['nullable', 'numeric', 'between:-180,180'],
             'radius' => ['nullable', 'numeric', 'gt:0', 'max:500'],
@@ -97,6 +102,7 @@ final class AdvancedPropertySearch extends Component
                 ->propertyType($this->propertyType)
                 ->country($this->country)
                 ->energyRating($this->energyRating)
+                ->hasAmenities($this->selectedAmenities)
                 ->when($this->latitude !== null && $this->longitude !== null && $this->radius !== null, fn ($query) => $query->nearby($this->latitude, $this->longitude, $this->radius))
                 ->when($this->featuredOnly, fn ($query) => $query->featured())
                 ->latest()->paginate(12);

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -124,6 +124,21 @@ final class Property extends Model
         });
     }
 
+    /** @param array<int, string> $amenities */
+    public function scopeHasAmenities(Builder $query, array $amenities): Builder
+    {
+        $amenities = array_values(array_filter(array_map(
+            static fn (mixed $amenity): string => trim((string) $amenity),
+            $amenities,
+        ), static fn (string $amenity): bool => $amenity !== ''));
+
+        foreach ($amenities as $amenity) {
+            $query->whereJsonContains('features', $amenity);
+        }
+
+        return $query;
+    }
+
     public function needsWalkabilityUpdate(): bool
     {
         return $this->walkability_updated_at === null

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -157,6 +157,21 @@ it('supports legacy nearby-property searching in kilometres', function () {
         ->and($results->first()->distance)->toBeLessThan(0.01);
 });
 
+it('supports legacy all-of amenity filtering through the modular JSON feature set', function () {
+    $matching = app(CreateProperty::class)->handle(10, 20, [
+        'address' => '1 High Street',
+        'features' => ['garden', 'parking'],
+    ]);
+    app(CreateProperty::class)->handle(10, 20, [
+        'address' => '2 Low Street',
+        'features' => ['garden'],
+    ]);
+
+    $results = Property::query()->forTeam(10)->hasAmenities(['garden', 'parking'])->get();
+
+    expect($results->pluck('id')->all())->toBe([$matching->getKey()]);
+});
+
 it('validates legacy property tour helpers and walkability freshness', function () {
     $property = app(CreateProperty::class)->handle(10, 20, [
         'address' => '1 High Street',


### PR DESCRIPTION
## Summary
- restore all-of amenity filtering using the modular JSON features field
- expose validated amenities[] API/OpenAPI filters
- add amenity controls to Livewire advanced property search
- add Filament property feature tags input
- cover combined amenity filtering

## Verification
- vendor/bin/pint --test
- vendor/bin/pest
