### PR TITLE
Carry legacy property categories into modular surfaces

### DIFF
--- a/modules/real-estate-properties-api/routes/api.php
+++ b/modules/real-estate-properties-api/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Liberu\RealEstate\PropertiesApi\Http\Controllers\PropertyController;
+use Liberu\RealEstate\PropertiesApi\Http\Controllers\PropertyCategoryController;
 
 Route::prefix('api/v1/real-estate/properties')->middleware(['api', 'auth:sanctum', 'throttle:api', 'api.idempotency'])->group(function (): void {
     Route::get('/', [PropertyController::class, 'index'])->name('real-estate.properties.index');
@@ -12,4 +13,11 @@ Route::prefix('api/v1/real-estate/properties')->middleware(['api', 'auth:sanctum
     Route::get('/{property}', [PropertyController::class, 'show'])->name('real-estate.properties.show');
     Route::match(['put', 'patch'], '/{property}', [PropertyController::class, 'update'])->name('real-estate.properties.update');
     Route::delete('/{property}', [PropertyController::class, 'destroy'])->name('real-estate.properties.destroy');
+});
+
+Route::prefix('api/v1/real-estate/property-categories')->middleware(['api', 'auth:sanctum', 'throttle:api', 'api.idempotency'])->group(function (): void {
+    Route::get('/', [PropertyCategoryController::class, 'index'])->name('real-estate.property-categories.index');
+    Route::post('/', [PropertyCategoryController::class, 'store'])->name('real-estate.property-categories.store');
+    Route::match(['put', 'patch'], '/{category}', [PropertyCategoryController::class, 'update'])->name('real-estate.property-categories.update');
+    Route::delete('/{category}', [PropertyCategoryController::class, 'destroy'])->name('real-estate.property-categories.destroy');
 });

--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyCategoryController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyCategoryController.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertiesApi\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Liberu\RealEstate\Properties\Models\PropertyCategory;
+use Liberu\RealEstate\PropertiesApi\Http\Resources\PropertyCategoryResource;
+
+final class PropertyCategoryController
+{
+    public function index(Request $request): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_unless($teamId !== null, 403);
+
+        return PropertyCategoryResource::collection(PropertyCategory::query()->forTeam($teamId)->orderBy('name')->get())->response();
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_unless($teamId !== null, 403);
+        $data = $request->validate(['name' => ['required', 'string', 'max:120'], 'slug' => ['sometimes', 'nullable', 'string', 'max:140']]);
+        $data['slug'] = str($data['slug'] ?? $data['name'])->slug()->limit(140, '')->toString();
+        abort_if(PropertyCategory::query()->forTeam($teamId)->where('slug', $data['slug'])->exists(), 422, 'The category slug is already in use.');
+
+        return (new PropertyCategoryResource(PropertyCategory::query()->create(['team_id' => $teamId, ...$data])))->response()->setStatusCode(201);
+    }
+
+    public function update(Request $request, PropertyCategory $category): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_unless($teamId !== null && (string) $category->team_id === (string) $teamId, 404);
+        $data = $request->validate(['name' => ['sometimes', 'string', 'max:120'], 'slug' => ['sometimes', 'string', 'max:140']]);
+        if (array_key_exists('name', $data) && ! array_key_exists('slug', $data)) {
+            $data['slug'] = str($data['name'])->slug()->limit(140, '')->toString();
+        }
+        if (isset($data['slug']) && PropertyCategory::query()->forTeam($teamId)->where('slug', $data['slug'])->where('id', '!=', $category->getKey())->exists()) {
+            abort(422, 'The category slug is already in use.');
+        }
+        $category->update($data);
+
+        return (new PropertyCategoryResource($category->fresh()))->response();
+    }
+
+    public function destroy(Request $request, PropertyCategory $category): Response
+    {
+        abort_unless((string) $request->user()?->current_team_id === (string) $category->team_id, 404);
+        $category->delete();
+
+        return response()->noContent();
+    }
+}

--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -47,6 +47,7 @@ final class PropertyController
             'min_area' => ['sometimes', 'nullable', 'numeric', 'min:0'],
             'max_area' => ['sometimes', 'nullable', 'numeric', 'min:0', 'gte:min_area'],
             'property_type' => ['sometimes', 'nullable', 'string', 'max:40'],
+            'property_category_id' => ['sometimes', 'nullable', 'integer', Rule::exists('real_estate_property_categories', 'id')->where('team_id', $teamId)],
             'country' => ['sometimes', 'nullable', 'string', 'size:2'],
             'energy_rating' => ['sometimes', 'nullable', 'string', 'max:10'],
             'featured' => ['sometimes', 'boolean'],
@@ -68,6 +69,7 @@ final class PropertyController
             ->bathrooms($filters['min_bathrooms'] ?? null, $filters['max_bathrooms'] ?? null)
             ->areaRange($filters['min_area'] ?? null, $filters['max_area'] ?? null)
             ->propertyType($filters['property_type'] ?? null)
+            ->category($filters['property_category_id'] ?? null)
             ->country($filters['country'] ?? null)
             ->energyRating($filters['energy_rating'] ?? null)
             ->when($filters['featured'] ?? false, fn ($query) => $query->featured())
@@ -139,6 +141,7 @@ final class PropertyController
             'insurance_expiry_date' => ['sometimes', 'nullable', 'date'],
             'jupix_id' => ['sometimes', 'nullable', 'string', 'max:255'],
             'property_type' => ['sometimes', 'string', 'max:40'],
+            'property_category_id' => ['sometimes', 'nullable', 'integer', Rule::exists('real_estate_property_categories', 'id')->where('team_id', $request->user()?->current_team_id)],
             'characteristics' => ['sometimes', 'array'],
             'utilities' => ['sometimes', 'array'],
             'features' => ['sometimes', 'array'],
@@ -221,6 +224,7 @@ final class PropertyController
             'insurance_expiry_date' => ['sometimes', 'nullable', 'date'],
             'jupix_id' => ['sometimes', 'nullable', 'string', 'max:255'],
             'property_type' => ['sometimes', 'string', 'max:40'],
+            'property_category_id' => ['sometimes', 'nullable', 'integer', Rule::exists('real_estate_property_categories', 'id')->where('team_id', $request->user()?->current_team_id)],
             'characteristics' => ['sometimes', 'array'],
             'utilities' => ['sometimes', 'array'],
             'features' => ['sometimes', 'array'],

--- a/modules/real-estate-properties-api/src/Http/Resources/PropertyCategoryResource.php
+++ b/modules/real-estate-properties-api/src/Http/Resources/PropertyCategoryResource.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertiesApi\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class PropertyCategoryResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        return $this->resource->only(['id', 'team_id', 'name', 'slug', 'created_at', 'updated_at']);
+    }
+}

--- a/modules/real-estate-properties-api/src/Http/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-api/src/Http/Resources/PropertyResource.php
@@ -12,6 +12,6 @@ final class PropertyResource extends JsonResource
     /** @return array<string, mixed> */
     public function toArray(Request $request): array
     {
-        return $this->resource->only(['id', 'team_id', 'branch_id', 'reference', 'address', 'status', 'property_type', 'bedrooms', 'bathrooms', 'price', 'area_sqft', 'service_charge', 'ground_rent', 'characteristics', 'utilities', 'features', 'structured_address', 'epc', 'floor_plan_data', 'latitude', 'longitude', 'last_synced_at', 'published_at', 'virtual_tour_url', 'virtual_tour_provider', 'model_3d_url', 'holographic_tour_url', 'holographic_provider', 'holographic_enabled', 'created_at', 'updated_at']) + ['is_hmo' => $this->resource->isHmo(), 'has_active_insurance' => $this->resource->hasActiveInsurance()];
+        return $this->resource->only(['id', 'team_id', 'branch_id', 'reference', 'address', 'status', 'property_type', 'property_category_id', 'bedrooms', 'bathrooms', 'price', 'area_sqft', 'service_charge', 'ground_rent', 'characteristics', 'utilities', 'features', 'structured_address', 'epc', 'floor_plan_data', 'latitude', 'longitude', 'last_synced_at', 'published_at', 'virtual_tour_url', 'virtual_tour_provider', 'model_3d_url', 'holographic_tour_url', 'holographic_provider', 'holographic_enabled', 'created_at', 'updated_at']) + ['is_hmo' => $this->resource->isHmo(), 'has_active_insurance' => $this->resource->hasActiveInsurance()];
     }
 }

--- a/modules/real-estate-properties-filament/module.json
+++ b/modules/real-estate-properties-filament/module.json
@@ -10,5 +10,5 @@
     "presentation": {"filament": {"admin": ["Liberu\\RealEstate\\PropertiesFilament\\PropertiesFilamentPlugin"]}},
     "capabilities": ["real-estate.properties.filament"],
     "default_enabled": true,
-    "features": ["Property resource", "Team-scoped property administration"]
+    "features": ["Property resource", "Property category resource", "Team-scoped property administration"]
 }

--- a/modules/real-estate-properties-filament/src/PropertiesFilamentPlugin.php
+++ b/modules/real-estate-properties-filament/src/PropertiesFilamentPlugin.php
@@ -7,6 +7,7 @@ namespace Liberu\RealEstate\PropertiesFilament;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
 use Liberu\RealEstate\PropertiesFilament\Resources\PropertyResource;
+use Liberu\RealEstate\PropertiesFilament\Resources\PropertyCategoryResource;
 
 final class PropertiesFilamentPlugin implements Plugin
 {
@@ -24,6 +25,7 @@ final class PropertiesFilamentPlugin implements Plugin
     {
         $panel->resources([
             PropertyResource::class,
+            PropertyCategoryResource::class,
         ]);
     }
 

--- a/modules/real-estate-properties-filament/src/Resources/PropertyCategoryResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyCategoryResource.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertiesFilament\Resources;
+
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Liberu\RealEstate\Properties\Models\PropertyCategory;
+use Liberu\RealEstate\PropertiesFilament\Resources\PropertyCategoryResource\Pages\CreatePropertyCategory;
+use Liberu\RealEstate\PropertiesFilament\Resources\PropertyCategoryResource\Pages\EditPropertyCategory;
+use Liberu\RealEstate\PropertiesFilament\Resources\PropertyCategoryResource\Pages\ListPropertyCategories;
+
+final class PropertyCategoryResource extends Resource
+{
+    protected static ?string $model = PropertyCategory::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-tag';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Real Estate';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('name')->required()->maxLength(120),
+            TextInput::make('slug')->maxLength(140)->helperText('Leave blank to derive from the name.'),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->modifyQueryUsing(function (Builder $query): Builder {
+            $teamId = auth()->user()?->current_team_id;
+
+            return $teamId === null ? $query->whereRaw('1 = 0') : $query->forTeam($teamId);
+        })->columns([
+            TextColumn::make('name')->searchable()->sortable(),
+            TextColumn::make('slug')->searchable(),
+            TextColumn::make('created_at')->dateTime()->sortable(),
+        ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListPropertyCategories::route('/'),
+            'create' => CreatePropertyCategory::route('/create'),
+            'edit' => EditPropertyCategory::route('/{record}/edit'),
+        ];
+    }
+}

--- a/modules/real-estate-properties-filament/src/Resources/PropertyCategoryResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyCategoryResource.php
@@ -44,6 +44,17 @@ final class PropertyCategoryResource extends Resource
         ]);
     }
 
+    public static function getEloquentQuery(): Builder
+    {
+        $teamId = auth()->user()?->current_team_id;
+
+        return parent::getEloquentQuery()->when(
+            $teamId === null,
+            fn (Builder $query): Builder => $query->whereRaw('1 = 0'),
+            fn (Builder $query): Builder => $query->forTeam($teamId),
+        );
+    }
+
     public static function getPages(): array
     {
         return [

--- a/modules/real-estate-properties-filament/src/Resources/PropertyCategoryResource/Pages/CreatePropertyCategory.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyCategoryResource/Pages/CreatePropertyCategory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertiesFilament\Resources\PropertyCategoryResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\RealEstate\Properties\Models\PropertyCategory;
+use Liberu\RealEstate\PropertiesFilament\Resources\PropertyCategoryResource;
+
+final class CreatePropertyCategory extends CreateRecord
+{
+    protected static string $resource = PropertyCategoryResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $teamId = auth()->user()?->current_team_id;
+        abort_unless($teamId !== null, 403);
+
+        return PropertyCategory::query()->create([
+            'team_id' => $teamId,
+            'name' => $data['name'],
+            'slug' => filled($data['slug'] ?? null) ? $data['slug'] : str($data['name'])->slug()->toString(),
+        ]);
+    }
+}

--- a/modules/real-estate-properties-filament/src/Resources/PropertyCategoryResource/Pages/EditPropertyCategory.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyCategoryResource/Pages/EditPropertyCategory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertiesFilament\Resources\PropertyCategoryResource\Pages;
+
+use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\RealEstate\PropertiesFilament\Resources\PropertyCategoryResource;
+
+final class EditPropertyCategory extends EditRecord
+{
+    protected static string $resource = PropertyCategoryResource::class;
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        abort_unless((string) auth()->user()?->current_team_id === (string) $record->team_id, 403);
+        $record->update([
+            'name' => $data['name'],
+            'slug' => filled($data['slug'] ?? null) ? $data['slug'] : str($data['name'])->slug()->toString(),
+        ]);
+
+        return $record;
+    }
+}

--- a/modules/real-estate-properties-filament/src/Resources/PropertyCategoryResource/Pages/ListPropertyCategories.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyCategoryResource/Pages/ListPropertyCategories.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertiesFilament\Resources\PropertyCategoryResource\Pages;
+
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Liberu\RealEstate\PropertiesFilament\Resources\PropertyCategoryResource;
+
+final class ListPropertyCategories extends ListRecords
+{
+    protected static string $resource = PropertyCategoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [CreateAction::make()];
+    }
+}

--- a/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
@@ -26,6 +26,7 @@ use Liberu\RealEstate\Properties\Application\TransitionProperty;
 use Liberu\RealEstate\Properties\Application\UpsertPropertyUnit;
 use Liberu\RealEstate\Properties\Domain\PropertyStatus;
 use Liberu\RealEstate\Properties\Models\Property;
+use Liberu\RealEstate\Properties\Models\PropertyCategory;
 use Liberu\RealEstate\PropertiesFilament\Resources\PropertyResource\Pages\CreateProperty;
 use Liberu\RealEstate\PropertiesFilament\Resources\PropertyResource\Pages\EditProperty;
 use Liberu\RealEstate\PropertiesFilament\Resources\PropertyResource\Pages\ListProperties;
@@ -70,6 +71,11 @@ final class PropertyResource extends Resource
                 'villa' => 'Villa',
                 'hmo' => 'HMO',
             ])->required(),
+            Select::make('property_category_id')
+                ->label('Category')
+                ->options(fn (): array => PropertyCategory::query()->forTeam(auth()->user()?->current_team_id ?? 0)->orderBy('name')->pluck('name', 'id')->all())
+                ->searchable()
+                ->nullable(),
             TextInput::make('postal_code')->maxLength(20),
             TextInput::make('country')->length(2),
             TextInput::make('tenure')->maxLength(40),

--- a/modules/real-estate-properties-livewire/module.json
+++ b/modules/real-estate-properties-livewire/module.json
@@ -9,5 +9,5 @@
     "requires": {"php": "^8.5", "laravel": "^13.0", "packages": {"liberusoftware/real-estate-properties": "^1.0"}},
     "capabilities": ["real-estate.properties.livewire"],
     "default_enabled": true,
-    "features": ["Property search state", "Advanced bounded filters", "Validation and empty states"]
+    "features": ["Property search state", "Category filtering", "Advanced bounded filters", "Validation and empty states"]
 }

--- a/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
@@ -11,6 +11,13 @@
         <input id="advanced-max-price" type="number" wire:model="maxPrice" min="0">
         <label for="advanced-property-type">Property type</label>
         <input id="advanced-property-type" type="text" wire:model="propertyType" maxlength="40">
+        <label for="advanced-property-category">Category</label>
+        <select id="advanced-property-category" wire:model="propertyCategoryId">
+            <option value="">Any category</option>
+            @foreach ($categories as $category)
+                <option value="{{ $category->getKey() }}">{{ $category->name }}</option>
+            @endforeach
+        </select>
         <label for="advanced-country">Country</label>
         <input id="advanced-country" type="text" wire:model="country" maxlength="2">
         <label for="advanced-latitude">Latitude</label>

--- a/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
+++ b/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
@@ -6,6 +6,7 @@ namespace Liberu\RealEstate\PropertiesLivewire\Components;
 
 use Illuminate\Contracts\View\View;
 use Liberu\RealEstate\Properties\Models\Property;
+use Liberu\RealEstate\Properties\Models\PropertyCategory;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -39,6 +40,8 @@ final class AdvancedPropertySearch extends Component
 
     public ?string $propertyType = null;
 
+    public ?int $propertyCategoryId = null;
+
     public ?string $country = null;
 
     public ?string $energyRating = null;
@@ -71,6 +74,7 @@ final class AdvancedPropertySearch extends Component
             'minArea' => ['nullable', 'numeric', 'min:0'],
             'maxArea' => ['nullable', 'numeric', 'min:0', 'gte:minArea'],
             'propertyType' => ['nullable', 'string', 'max:40'],
+            'propertyCategoryId' => ['nullable', 'integer', 'exists:real_estate_property_categories,id'],
             'postalCode' => ['nullable', 'string', 'max:20'],
             'country' => ['nullable', 'string', 'size:2'],
             'energyRating' => ['nullable', 'string', 'max:10'],
@@ -89,6 +93,7 @@ final class AdvancedPropertySearch extends Component
     public function render(): View
     {
         $teamId = auth()->user()?->current_team_id;
+        $categories = $teamId === null ? collect() : PropertyCategory::query()->forTeam($teamId)->orderBy('name')->get();
         $properties = $teamId === null
             ? Property::query()->whereRaw('1 = 0')->paginate(12)
             : Property::query()->forTeam($teamId)
@@ -100,6 +105,7 @@ final class AdvancedPropertySearch extends Component
                 ->bathrooms($this->minBathrooms, $this->maxBathrooms)
                 ->areaRange($this->minArea, $this->maxArea)
                 ->propertyType($this->propertyType)
+                ->category($this->propertyCategoryId)
                 ->country($this->country)
                 ->energyRating($this->energyRating)
                 ->hasAmenities($this->selectedAmenities)
@@ -107,6 +113,6 @@ final class AdvancedPropertySearch extends Component
                 ->when($this->featuredOnly, fn ($query) => $query->featured())
                 ->latest()->paginate(12);
 
-        return view('real-estate-properties-livewire::advanced-property-search', compact('properties'));
+        return view('real-estate-properties-livewire::advanced-property-search', compact('properties', 'categories'));
     }
 }

--- a/modules/real-estate-properties/database/migrations/2026_08_29_000001_add_property_categories.php
+++ b/modules/real-estate-properties/database/migrations/2026_08_29_000001_add_property_categories.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('real_estate_property_categories', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('team_id')->index();
+            $table->string('name', 120);
+            $table->string('slug', 140);
+            $table->timestamps();
+
+            $table->unique(['team_id', 'slug']);
+        });
+
+        Schema::table('real_estate_properties', function (Blueprint $table): void {
+            $table->foreignId('property_category_id')
+                ->nullable()
+                ->after('property_type')
+                ->constrained('real_estate_property_categories')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('real_estate_properties', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('property_category_id');
+        });
+
+        Schema::dropIfExists('real_estate_property_categories');
+    }
+};

--- a/modules/real-estate-properties/module.json
+++ b/modules/real-estate-properties/module.json
@@ -2,7 +2,7 @@
     "$schema": "https://schemas.liberu.dev/module/v1.json",
     "name": "real-estate-properties",
     "display_name": "Real Estate Properties",
-    "description": "Address, units, characteristics, tenure, utilities, features, status, history, and keys.",
+    "description": "Address, categories, units, characteristics, tenure, utilities, features, status, history, and keys.",
     "version": "1.0.1",
     "category": "product",
     "provider": "Liberu\\RealEstate\\Properties\\PropertiesServiceProvider",
@@ -23,6 +23,6 @@
     "capabilities": ["real-estate.properties"],
     "default_enabled": true,
     "features": [
-        "Address/location", "Units", "Characteristics", "Tenure", "Utilities", "Features", "Status", "History", "Keys"
+        "Address/location", "Categories", "Units", "Characteristics", "Tenure", "Utilities", "Features", "Status", "History", "Keys"
     ]
 }

--- a/modules/real-estate-properties/src/Application/CreateProperty.php
+++ b/modules/real-estate-properties/src/Application/CreateProperty.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 use Liberu\RealEstate\Core\Models\Branch;
 use Liberu\RealEstate\Properties\Domain\PropertyStatus;
+use Liberu\RealEstate\Properties\Models\PropertyCategory;
 use Liberu\RealEstate\Properties\Models\Property;
 
 final class CreateProperty
@@ -24,8 +25,12 @@ final class CreateProperty
         if ($branchId !== null && ! Branch::query()->forTeam($teamId)->whereKey($branchId)->exists()) {
             throw ValidationException::withMessages(['branch_id' => 'The branch must belong to the current team.']);
         }
+        $categoryId = $attributes['property_category_id'] ?? null;
+        if ($categoryId !== null && ! PropertyCategory::query()->forTeam($teamId)->whereKey($categoryId)->exists()) {
+            throw ValidationException::withMessages(['property_category_id' => 'The category must belong to the current team.']);
+        }
 
-        return DB::transaction(function () use ($teamId, $actorId, $attributes, $address): Property {
+        return DB::transaction(function () use ($teamId, $actorId, $attributes, $address, $categoryId): Property {
             $property = Property::query()->create([
                 'team_id' => $teamId,
                 'branch_id' => $attributes['branch_id'] ?? null,
@@ -86,6 +91,7 @@ final class CreateProperty
                 'insurance_expiry_date' => $attributes['insurance_expiry_date'] ?? null,
                 'jupix_id' => $attributes['jupix_id'] ?? null,
                 'property_type' => $attributes['property_type'] ?? 'residential',
+                'property_category_id' => $categoryId,
                 'characteristics' => $attributes['characteristics'] ?? [],
                 'utilities' => $attributes['utilities'] ?? [],
                 'features' => $attributes['features'] ?? [],

--- a/modules/real-estate-properties/src/Application/UpdateProperty.php
+++ b/modules/real-estate-properties/src/Application/UpdateProperty.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 use Liberu\RealEstate\Core\Models\Branch;
 use Liberu\RealEstate\Properties\Models\Property;
+use Liberu\RealEstate\Properties\Models\PropertyCategory;
 
 final class UpdateProperty
 {
@@ -30,6 +31,9 @@ final class UpdateProperty
             if (array_key_exists('branch_id', $attributes) && $attributes['branch_id'] !== null && ! Branch::query()->forTeam($teamId)->whereKey($attributes['branch_id'])->exists()) {
                 throw ValidationException::withMessages(['branch_id' => 'The branch must belong to the current team.']);
             }
+            if (array_key_exists('property_category_id', $attributes) && $attributes['property_category_id'] !== null && ! PropertyCategory::query()->forTeam($teamId)->whereKey($attributes['property_category_id'])->exists()) {
+                throw ValidationException::withMessages(['property_category_id' => 'The category must belong to the current team.']);
+            }
             $changes = [];
 
             $fields = [
@@ -39,7 +43,7 @@ final class UpdateProperty
                 'council_tax_band', 'energy_score', 'walkability_score', 'walkability_description',
                 'transit_score', 'transit_description', 'bike_score', 'bike_description',
                 'walkability_updated_at',
-                'virtual_tour_url', 'virtual_tour_provider', 'model_3d_url', 'floor_plan_data', 'property_type',
+                'virtual_tour_url', 'virtual_tour_provider', 'model_3d_url', 'floor_plan_data', 'property_type', 'property_category_id',
                 'characteristics', 'utilities', 'features', 'list_date', 'sold_date', 'last_synced_at', 'is_featured',
                 'live_tour_available', 'ar_tour_enabled', 'ar_tour_settings', 'ar_placement_guide',
                 'ar_model_scale', 'holographic_tour_url', 'holographic_provider', 'holographic_metadata',

--- a/modules/real-estate-properties/src/Domain/PropertiesCapabilityDefinition.php
+++ b/modules/real-estate-properties/src/Domain/PropertiesCapabilityDefinition.php
@@ -9,7 +9,7 @@ final class PropertiesCapabilityDefinition
     /** @return array<string, array{label: string, required: list<string>, behaviors: list<string>}> */
     public static function all(): array
     {
-        $labels = ['Address/location', 'Units', 'Characteristics', 'Tenure', 'Utilities', 'Features', 'Status', 'History', 'Keys'];
+        $labels = ['Address/location', 'Categories', 'Units', 'Characteristics', 'Tenure', 'Utilities', 'Features', 'Status', 'History', 'Keys'];
         $result = [];
         foreach ($labels as $label) {
             $key = strtolower(str_replace([' ', '/', '-'], ['_', '_', '_'], $label));

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -63,6 +63,11 @@ final class Property extends Model
         return $this->belongsTo(Branch::class);
     }
 
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(PropertyCategory::class, 'property_category_id');
+    }
+
     public function scopeForTeam(Builder $query, int|string $teamId): Builder
     {
         return $query->where('team_id', $teamId);
@@ -215,6 +220,11 @@ final class Property extends Model
     public function scopePropertyType(Builder $query, ?string $type): Builder
     {
         return $query->when(filled($type), fn (Builder $query): Builder => $query->where('property_type', $type));
+    }
+
+    public function scopeCategory(Builder $query, int|string|null $category): Builder
+    {
+        return $query->when($category !== null && $category !== '', fn (Builder $query): Builder => $query->where('property_category_id', $category));
     }
 
     public function scopeCountry(Builder $query, ?string $country): Builder

--- a/modules/real-estate-properties/src/Models/PropertyCategory.php
+++ b/modules/real-estate-properties/src/Models/PropertyCategory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\Properties\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+final class PropertyCategory extends Model
+{
+    protected $table = 'real_estate_property_categories';
+
+    protected $guarded = ['id'];
+
+    public function properties(): HasMany
+    {
+        return $this->hasMany(Property::class, 'property_category_id');
+    }
+
+    public function scopeForTeam(Builder $query, int|string $teamId): Builder
+    {
+        return $query->where('team_id', $teamId);
+    }
+}

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -11,6 +11,7 @@ use Liberu\RealEstate\Properties\Application\UpdateProperty;
 use Liberu\RealEstate\Properties\Application\UpsertPropertyUnit;
 use Liberu\RealEstate\Properties\Domain\PropertyStatus;
 use Liberu\RealEstate\Properties\Models\Property;
+use Liberu\RealEstate\Properties\Models\PropertyCategory;
 
 it('updates team properties and retains a change history', function () {
     expect(Schema::hasTable('real_estate_properties'))->toBeTrue();
@@ -170,6 +171,26 @@ it('supports legacy all-of amenity filtering through the modular JSON feature se
     $results = Property::query()->forTeam(10)->hasAmenities(['garden', 'parking'])->get();
 
     expect($results->pluck('id')->all())->toBe([$matching->getKey()]);
+});
+
+it('supports tenant-scoped property categories and category filtering', function (): void {
+    $category = PropertyCategory::query()->create([
+        'team_id' => 10,
+        'name' => 'Investment Homes',
+        'slug' => 'investment-homes',
+    ]);
+    $matching = app(CreateProperty::class)->handle(10, 20, [
+        'address' => '1 High Street',
+        'property_category_id' => $category->getKey(),
+    ]);
+    app(CreateProperty::class)->handle(11, 21, ['address' => '2 Low Street']);
+
+    expect($matching->category->is($category))->toBeTrue()
+        ->and(Property::query()->forTeam(10)->category($category->getKey())->pluck('id')->all())->toBe([$matching->getKey()])
+        ->and(fn () => app(CreateProperty::class)->handle(11, 21, [
+            'address' => '3 Other Street',
+            'property_category_id' => $category->getKey(),
+        ]))->toThrow(ValidationException::class);
 });
 
 it('validates legacy property tour helpers and walkability freshness', function () {


### PR DESCRIPTION
Implements the next old-branch parity slice with tenant-scoped property categories across core, API, Livewire, and Filament. Adds category assignment/filtering, authorized category management, admin resource, migration, and coverage. Full suite: 277 passed, 12 skipped, 1,404 assertions.