### PR TITLE
Carry legacy property favorites into modular surfaces

### DIFF
--- a/modules/real-estate-properties-api/routes/api.php
+++ b/modules/real-estate-properties-api/routes/api.php
@@ -9,6 +9,7 @@ Route::prefix('api/v1/real-estate/properties')->middleware(['api', 'auth:sanctum
     Route::get('/', [PropertyController::class, 'index'])->name('real-estate.properties.index');
     Route::post('/', [PropertyController::class, 'store'])->name('real-estate.properties.store');
     Route::post('/{property}/transition/{status}', [PropertyController::class, 'transition'])->name('real-estate.properties.transition');
+    Route::post('/{property}/favorite', [PropertyController::class, 'favorite'])->name('real-estate.properties.favorite');
     Route::put('/{property}/units', [PropertyController::class, 'unit'])->name('real-estate.properties.units');
     Route::post('/{property}/keys', [PropertyController::class, 'key'])->name('real-estate.properties.keys');
     Route::get('/{property}', [PropertyController::class, 'show'])->name('real-estate.properties.show');

--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -12,6 +12,7 @@ use Liberu\RealEstate\Properties\Application\CreateProperty;
 use Liberu\RealEstate\Properties\Application\DeleteProperty;
 use Liberu\RealEstate\Properties\Application\RecordPropertyKey;
 use Liberu\RealEstate\Properties\Application\TransitionProperty;
+use Liberu\RealEstate\Properties\Application\TogglePropertyFavorite;
 use Liberu\RealEstate\Properties\Application\UpdateProperty;
 use Liberu\RealEstate\Properties\Application\UpsertPropertyUnit;
 use Liberu\RealEstate\Properties\Domain\PropertyStatus;
@@ -52,6 +53,7 @@ final class PropertyController
             'country' => ['sometimes', 'nullable', 'string', 'size:2'],
             'energy_rating' => ['sometimes', 'nullable', 'string', 'max:10'],
             'featured' => ['sometimes', 'boolean'],
+            'favorites_only' => ['sometimes', 'boolean'],
             'min_energy_score' => ['sometimes', 'nullable', 'integer', 'between:0,100'],
             'min_walkability_score' => ['sometimes', 'nullable', 'integer', 'between:0,100'],
             'min_transit_score' => ['sometimes', 'nullable', 'integer', 'between:0,100'],
@@ -74,6 +76,7 @@ final class PropertyController
             ->country($filters['country'] ?? null)
             ->energyRating($filters['energy_rating'] ?? null)
             ->when($filters['featured'] ?? false, fn ($query) => $query->featured())
+            ->when($filters['favorites_only'] ?? false, fn ($query) => $query->favoritedBy($teamId, $request->user()->getAuthIdentifier()))
             ->minimumScore('energy_score', $filters['min_energy_score'] ?? null)
             ->minimumScore('walkability_score', $filters['min_walkability_score'] ?? null)
             ->minimumScore('transit_score', $filters['min_transit_score'] ?? null)
@@ -157,6 +160,14 @@ final class PropertyController
         $property = $create->handle($user->current_team_id, $user->getAuthIdentifier(), $validated);
 
         return (new PropertyResource($property))->response()->setStatusCode(201);
+    }
+
+    public function favorite(Request $request, Property $property, TogglePropertyFavorite $toggle): JsonResponse
+    {
+        $user = $request->user();
+        abort_unless($user?->current_team_id === $property->team_id, 404);
+
+        return response()->json(['favorited' => $toggle->handle($property->team_id, $user->getAuthIdentifier(), $property->getKey())]);
     }
 
     public function show(Request $request, Property $property): JsonResponse

--- a/modules/real-estate-properties-api/src/Http/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-api/src/Http/Resources/PropertyResource.php
@@ -6,12 +6,20 @@ namespace Liberu\RealEstate\PropertiesApi\Http\Resources;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Liberu\RealEstate\Properties\Models\PropertyFavorite;
 
 final class PropertyResource extends JsonResource
 {
     /** @return array<string, mixed> */
     public function toArray(Request $request): array
     {
-        return $this->resource->only(['id', 'team_id', 'branch_id', 'reference', 'address', 'status', 'property_type', 'property_category_id', 'property_template_id', 'bedrooms', 'bathrooms', 'price', 'area_sqft', 'service_charge', 'ground_rent', 'characteristics', 'utilities', 'features', 'structured_address', 'epc', 'floor_plan_data', 'floor_plan_image', 'latitude', 'longitude', 'last_synced_at', 'published_at', 'virtual_tour_url', 'virtual_tour_provider', 'model_3d_url', 'holographic_tour_url', 'holographic_provider', 'holographic_enabled', 'description_generated_at', 'internal_notes', 'created_at', 'updated_at']) + ['is_hmo' => $this->resource->isHmo(), 'has_active_insurance' => $this->resource->hasActiveInsurance()];
+        $user = $request->user();
+        $isFavorited = $user?->current_team_id !== null && PropertyFavorite::query()
+            ->where('team_id', $user->current_team_id)
+            ->where('user_id', $user->getAuthIdentifier())
+            ->where('property_id', $this->resource->getKey())
+            ->exists();
+
+        return $this->resource->only(['id', 'team_id', 'branch_id', 'reference', 'address', 'status', 'property_type', 'property_category_id', 'property_template_id', 'bedrooms', 'bathrooms', 'price', 'area_sqft', 'service_charge', 'ground_rent', 'characteristics', 'utilities', 'features', 'structured_address', 'epc', 'floor_plan_data', 'floor_plan_image', 'latitude', 'longitude', 'last_synced_at', 'published_at', 'virtual_tour_url', 'virtual_tour_provider', 'model_3d_url', 'holographic_tour_url', 'holographic_provider', 'holographic_enabled', 'description_generated_at', 'internal_notes', 'created_at', 'updated_at']) + ['is_hmo' => $this->resource->isHmo(), 'has_active_insurance' => $this->resource->hasActiveInsurance(), 'is_favorited' => $isFavorited];
     }
 }

--- a/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
@@ -126,6 +126,9 @@ final class PropertyResource extends Resource
             ])
             ->recordActions([
                 EditAction::make(),
+                Action::make('favorite')
+                    ->label('Toggle favorite')
+                    ->action(fn (Property $record): bool => app(\Liberu\RealEstate\Properties\Application\TogglePropertyFavorite::class)->handle($record->team_id, auth()->id(), $record->getKey())),
                 Action::make('unit')->form([TextInput::make('label')->required()->maxLength(80), TextInput::make('bedrooms')->numeric()->minValue(0), TextInput::make('bathrooms')->numeric()->minValue(0), TextInput::make('area_sqft')->numeric()->minValue(0)])->action(fn (Property $record, array $data): mixed => app(UpsertPropertyUnit::class)->handle($record, (int) auth()->user()->current_team_id, $data)),
                 Action::make('key')->form([TextInput::make('key_reference')->required()->maxLength(80), TextInput::make('quantity')->numeric()->required()->minValue(1), Textarea::make('notes')])->action(fn (Property $record, array $data): mixed => app(RecordPropertyKey::class)->handle($record, (int) auth()->user()->current_team_id, $data)),
                 Action::make('available')

--- a/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
@@ -25,6 +25,9 @@
         @forelse ($properties as $property)
             <li wire:key="property-{{ $property->getKey() }}">
                 {{ $property->address }} ({{ $property->status->value }})
+                <button type="button" wire:click="toggleFavorite({{ $property->getKey() }})">
+                    {{ $property->favorites->contains(fn ($favorite) => (string) $favorite->user_id === (string) auth()->id()) ? 'Unfavorite' : 'Favorite' }}
+                </button>
                 @if ($property->isHmo())
                     <span aria-label="House in multiple occupation">HMO</span>
                 @endif

--- a/modules/real-estate-properties-livewire/src/Components/PropertyList.php
+++ b/modules/real-estate-properties-livewire/src/Components/PropertyList.php
@@ -7,6 +7,7 @@ namespace Liberu\RealEstate\PropertiesLivewire\Components;
 use Illuminate\Contracts\View\View;
 use Liberu\RealEstate\Properties\Application\RecordPropertyKey;
 use Liberu\RealEstate\Properties\Application\TransitionProperty;
+use Liberu\RealEstate\Properties\Application\TogglePropertyFavorite;
 use Liberu\RealEstate\Properties\Application\UpsertPropertyUnit;
 use Liberu\RealEstate\Properties\Domain\PropertyStatus;
 use Liberu\RealEstate\Properties\Models\Property;
@@ -36,6 +37,13 @@ final class PropertyList extends Component
     public ?int $maxBedrooms = null;
 
     public bool $featuredOnly = false;
+
+    public function toggleFavorite(int $propertyId, TogglePropertyFavorite $toggle): void
+    {
+        $user = auth()->user();
+        abort_unless($user?->current_team_id !== null, 403);
+        $toggle->handle($user->current_team_id, $user->getAuthIdentifier(), $propertyId);
+    }
 
     public ?string $error = null;
 

--- a/modules/real-estate-properties/database/migrations/2026_08_29_000004_add_property_favorites.php
+++ b/modules/real-estate-properties/database/migrations/2026_08_29_000004_add_property_favorites.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('real_estate_property_favorites', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('team_id')->index();
+            $table->unsignedBigInteger('user_id')->index();
+            $table->foreignId('property_id')->constrained('real_estate_properties')->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['team_id', 'user_id', 'property_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('real_estate_property_favorites');
+    }
+};

--- a/modules/real-estate-properties/module.json
+++ b/modules/real-estate-properties/module.json
@@ -23,6 +23,6 @@
     "capabilities": ["real-estate.properties"],
     "default_enabled": true,
     "features": [
-        "Address/location", "Categories", "Templates", "Units", "Characteristics", "Tenure", "Utilities", "Features", "Status", "History", "Keys"
+        "Address/location", "Categories", "Templates", "Favorites", "Units", "Characteristics", "Tenure", "Utilities", "Features", "Status", "History", "Keys"
     ]
 }

--- a/modules/real-estate-properties/src/Application/TogglePropertyFavorite.php
+++ b/modules/real-estate-properties/src/Application/TogglePropertyFavorite.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\Properties\Application;
+
+use Illuminate\Support\Facades\DB;
+use Liberu\RealEstate\Properties\Models\Property;
+use Liberu\RealEstate\Properties\Models\PropertyFavorite;
+
+final class TogglePropertyFavorite
+{
+    public function handle(int|string $teamId, int|string $userId, int|string $propertyId): bool
+    {
+        $property = Property::query()->forTeam($teamId)->findOrFail($propertyId);
+        $favorite = PropertyFavorite::query()
+            ->where('team_id', $teamId)
+            ->where('user_id', $userId)
+            ->where('property_id', $property->getKey())
+            ->first();
+
+        if ($favorite !== null) {
+            $favorite->delete();
+
+            return false;
+        }
+
+        DB::transaction(fn () => PropertyFavorite::query()->create([
+            'team_id' => $teamId,
+            'user_id' => $userId,
+            'property_id' => $property->getKey(),
+        ]));
+
+        return true;
+    }
+}

--- a/modules/real-estate-properties/src/Domain/PropertiesCapabilityDefinition.php
+++ b/modules/real-estate-properties/src/Domain/PropertiesCapabilityDefinition.php
@@ -9,7 +9,7 @@ final class PropertiesCapabilityDefinition
     /** @return array<string, array{label: string, required: list<string>, behaviors: list<string>}> */
     public static function all(): array
     {
-        $labels = ['Address/location', 'Categories', 'Templates', 'Units', 'Characteristics', 'Tenure', 'Utilities', 'Features', 'Status', 'History', 'Keys'];
+        $labels = ['Address/location', 'Categories', 'Templates', 'Favorites', 'Units', 'Characteristics', 'Tenure', 'Utilities', 'Features', 'Status', 'History', 'Keys'];
         $result = [];
         foreach ($labels as $label) {
             $key = strtolower(str_replace([' ', '/', '-'], ['_', '_', '_'], $label));

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -64,6 +64,11 @@ final class Property extends Model
         return $this->hasMany(PropertyHistory::class, 'property_id');
     }
 
+    public function favorites(): HasMany
+    {
+        return $this->hasMany(PropertyFavorite::class);
+    }
+
     public function branch(): BelongsTo
     {
         return $this->belongsTo(Branch::class);
@@ -236,6 +241,13 @@ final class Property extends Model
     public function scopeCategory(Builder $query, int|string|null $category): Builder
     {
         return $query->when($category !== null && $category !== '', fn (Builder $query): Builder => $query->where('property_category_id', $category));
+    }
+
+    public function scopeFavoritedBy(Builder $query, int|string $teamId, int|string $userId): Builder
+    {
+        return $query->whereHas('favorites', fn (Builder $favorites): Builder => $favorites
+            ->where('team_id', $teamId)
+            ->where('user_id', $userId));
     }
 
     public function scopeCountry(Builder $query, ?string $country): Builder

--- a/modules/real-estate-properties/src/Models/PropertyFavorite.php
+++ b/modules/real-estate-properties/src/Models/PropertyFavorite.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\Properties\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+final class PropertyFavorite extends Model
+{
+    protected $table = 'real_estate_property_favorites';
+
+    protected $guarded = ['id'];
+
+    public function property(): BelongsTo
+    {
+        return $this->belongsTo(Property::class);
+    }
+}

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -13,6 +13,7 @@ use Liberu\RealEstate\Properties\Domain\PropertyStatus;
 use Liberu\RealEstate\Properties\Models\Property;
 use Liberu\RealEstate\Properties\Models\PropertyCategory;
 use Liberu\RealEstate\Properties\Models\PropertyTemplate;
+use Liberu\RealEstate\Properties\Models\PropertyFavorite;
 
 it('updates team properties and retains a change history', function () {
     expect(Schema::hasTable('real_estate_properties'))->toBeTrue();
@@ -226,6 +227,18 @@ it('preserves legacy property metadata and year normalization', function (): voi
         ->and($property->description_generated_at)->not->toBeNull()
         ->and($property->internal_notes)->toBe('Review title documents.')
         ->and($property->floor_plan_image)->toBe('https://example.test/floor-plan.png');
+});
+
+it('supports tenant and user-scoped property favorites', function (): void {
+    $property = app(CreateProperty::class)->handle(10, 20, ['address' => '1 High Street']);
+    $otherUserProperty = app(CreateProperty::class)->handle(10, 21, ['address' => '2 High Street']);
+
+    expect(app(\Liberu\RealEstate\Properties\Application\TogglePropertyFavorite::class)->handle(10, 20, $property->getKey()))->toBeTrue()
+        ->and(Property::query()->forTeam(10)->favoritedBy(10, 20)->pluck('id')->all())->toBe([$property->getKey()])
+        ->and(PropertyFavorite::query()->where('user_id', 21)->exists())->toBeFalse()
+        ->and(app(\Liberu\RealEstate\Properties\Application\TogglePropertyFavorite::class)->handle(10, 20, $property->getKey()))->toBeFalse()
+        ->and(Property::query()->forTeam(10)->favoritedBy(10, 20)->exists())->toBeFalse()
+        ->and(fn () => app(\Liberu\RealEstate\Properties\Application\TogglePropertyFavorite::class)->handle(11, 20, $otherUserProperty->getKey()))->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
 });
 
 it('validates legacy property tour helpers and walkability freshness', function () {


### PR DESCRIPTION
Carries legacy property favorites into the modular properties boundary with tenant/user-safe persistence, toggle action, API endpoint and favorites-only filtering, Livewire controls, Filament action, migration, and regression coverage. Full suite: 280 passed, 12 skipped, 1,422 assertions.