### PR TITLE
Carry legacy similar property matching into modular surfaces

### DIFF
--- a/modules/real-estate-properties-api/routes/api.php
+++ b/modules/real-estate-properties-api/routes/api.php
@@ -10,6 +10,7 @@ Route::prefix('api/v1/real-estate/properties')->middleware(['api', 'auth:sanctum
     Route::post('/', [PropertyController::class, 'store'])->name('real-estate.properties.store');
     Route::post('/{property}/transition/{status}', [PropertyController::class, 'transition'])->name('real-estate.properties.transition');
     Route::post('/{property}/favorite', [PropertyController::class, 'favorite'])->name('real-estate.properties.favorite');
+    Route::get('/{property}/similar', [PropertyController::class, 'similar'])->name('real-estate.properties.similar');
     Route::put('/{property}/units', [PropertyController::class, 'unit'])->name('real-estate.properties.units');
     Route::post('/{property}/keys', [PropertyController::class, 'key'])->name('real-estate.properties.keys');
     Route::get('/{property}', [PropertyController::class, 'show'])->name('real-estate.properties.show');

--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -170,6 +170,14 @@ final class PropertyController
         return response()->json(['favorited' => $toggle->handle($property->team_id, $user->getAuthIdentifier(), $property->getKey())]);
     }
 
+    public function similar(Request $request, Property $property): JsonResponse
+    {
+        abort_unless($request->user()?->current_team_id === $property->team_id, 404);
+        $limit = max(1, min($request->integer('limit', 3), 20));
+
+        return PropertyResource::collection($property->similarProperties($limit))->response();
+    }
+
     public function show(Request $request, Property $property): JsonResponse
     {
         abort_unless($request->user()?->current_team_id === $property->team_id, 404);

--- a/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
@@ -18,6 +18,7 @@ use Filament\Resources\Pages\PageRegistration;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Notifications\Notification;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Liberu\RealEstate\Core\Models\Branch;
@@ -129,6 +130,14 @@ final class PropertyResource extends Resource
                 Action::make('favorite')
                     ->label('Toggle favorite')
                     ->action(fn (Property $record): bool => app(\Liberu\RealEstate\Properties\Application\TogglePropertyFavorite::class)->handle($record->team_id, auth()->id(), $record->getKey())),
+                Action::make('similar')
+                    ->label('Similar properties')
+                    ->action(function (Property $record): void {
+                        Notification::make()
+                            ->title($record->similarProperties()->count().' similar properties found')
+                            ->success()
+                            ->send();
+                    }),
                 Action::make('unit')->form([TextInput::make('label')->required()->maxLength(80), TextInput::make('bedrooms')->numeric()->minValue(0), TextInput::make('bathrooms')->numeric()->minValue(0), TextInput::make('area_sqft')->numeric()->minValue(0)])->action(fn (Property $record, array $data): mixed => app(UpsertPropertyUnit::class)->handle($record, (int) auth()->user()->current_team_id, $data)),
                 Action::make('key')->form([TextInput::make('key_reference')->required()->maxLength(80), TextInput::make('quantity')->numeric()->required()->minValue(1), Textarea::make('notes')])->action(fn (Property $record, array $data): mixed => app(RecordPropertyKey::class)->handle($record, (int) auth()->user()->current_team_id, $data)),
                 Action::make('available')

--- a/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
@@ -28,6 +28,7 @@
                 <button type="button" wire:click="toggleFavorite({{ $property->getKey() }})">
                     {{ $property->favorites->contains(fn ($favorite) => (string) $favorite->user_id === (string) auth()->id()) ? 'Unfavorite' : 'Favorite' }}
                 </button>
+                <button type="button" wire:click="showSimilar({{ $property->getKey() }})">Similar</button>
                 @if ($property->isHmo())
                     <span aria-label="House in multiple occupation">HMO</span>
                 @endif
@@ -56,4 +57,14 @@
             <li>No properties match this search.</li>
         @endforelse
     </ul>
+    @if ($similarProperties !== [])
+        <section aria-label="Similar properties">
+            <h2>Similar properties</h2>
+            <ul>
+                @foreach ($similarProperties as $similar)
+                    <li wire:key="similar-property-{{ $similar['id'] }}">{{ $similar['title'] }}</li>
+                @endforeach
+            </ul>
+        </section>
+    @endif
 </div>

--- a/modules/real-estate-properties-livewire/src/Components/PropertyList.php
+++ b/modules/real-estate-properties-livewire/src/Components/PropertyList.php
@@ -38,6 +38,20 @@ final class PropertyList extends Component
 
     public bool $featuredOnly = false;
 
+    /** @var array<int, array<string, mixed>> */
+    public array $similarProperties = [];
+
+    public function showSimilar(int $propertyId): void
+    {
+        $user = auth()->user();
+        abort_unless($user?->current_team_id !== null, 403);
+        $property = Property::query()->forTeam($user->current_team_id)->findOrFail($propertyId);
+        $this->similarProperties = $property->similarProperties()->map(fn (Property $similar): array => [
+            'id' => $similar->getKey(),
+            'title' => $similar->title ?: $similar->address,
+        ])->all();
+    }
+
     public function toggleFavorite(int $propertyId, TogglePropertyFavorite $toggle): void
     {
         $user = auth()->user();

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liberu\RealEstate\Properties\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -248,6 +249,23 @@ final class Property extends Model
         return $query->whereHas('favorites', fn (Builder $favorites): Builder => $favorites
             ->where('team_id', $teamId)
             ->where('user_id', $userId));
+    }
+
+    public function similarProperties(int $limit = 3): Collection
+    {
+        if ($this->price === null || $this->bedrooms === null || $this->bathrooms === null) {
+            return new Collection();
+        }
+
+        return self::query()
+            ->forTeam($this->team_id)
+            ->where('id', '!=', $this->getKey())
+            ->where('property_type', $this->property_type)
+            ->whereBetween('price', [(float) $this->price * 0.8, (float) $this->price * 1.2])
+            ->whereBetween('bedrooms', [(int) $this->bedrooms - 1, (int) $this->bedrooms + 1])
+            ->whereBetween('bathrooms', [(int) $this->bathrooms - 1, (int) $this->bathrooms + 1])
+            ->limit(max(1, min($limit, 20)))
+            ->get();
     }
 
     public function scopeCountry(Builder $query, ?string $country): Builder

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -241,6 +241,40 @@ it('supports tenant and user-scoped property favorites', function (): void {
         ->and(fn () => app(\Liberu\RealEstate\Properties\Application\TogglePropertyFavorite::class)->handle(11, 20, $otherUserProperty->getKey()))->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
 });
 
+it('preserves legacy similar-property matching within the property boundary', function (): void {
+    $source = app(CreateProperty::class)->handle(10, 20, [
+        'address' => '1 High Street',
+        'property_type' => 'house',
+        'price' => 300000,
+        'bedrooms' => 3,
+        'bathrooms' => 2,
+    ]);
+    $similar = app(CreateProperty::class)->handle(10, 21, [
+        'address' => '2 High Street',
+        'property_type' => 'house',
+        'price' => 330000,
+        'bedrooms' => 4,
+        'bathrooms' => 1,
+    ]);
+    app(CreateProperty::class)->handle(10, 22, [
+        'address' => '3 High Street',
+        'property_type' => 'apartment',
+        'price' => 300000,
+        'bedrooms' => 3,
+        'bathrooms' => 2,
+    ]);
+    app(CreateProperty::class)->handle(11, 23, [
+        'address' => '4 Other Street',
+        'property_type' => 'house',
+        'price' => 300000,
+        'bedrooms' => 3,
+        'bathrooms' => 2,
+    ]);
+
+    expect($source->similarProperties()->pluck('id')->all())->toBe([$similar->getKey()])
+        ->and($source->similarProperties(0))->toHaveCount(1);
+});
+
 it('validates legacy property tour helpers and walkability freshness', function () {
     $property = app(CreateProperty::class)->handle(10, 20, [
         'address' => '1 High Street',


### PR DESCRIPTION
Implements the remaining property-local legacy similar-property behavior across the core property model, API endpoint, Livewire list, and Filament action. Adds coverage for matching criteria, team isolation, source exclusion, and bounded limits. Standalone module changes are merged in the corresponding module repositories.