### PR TITLE
Centralize legacy property build-year behavior

### DIFF
--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -47,6 +47,8 @@ final class PropertyController
             'max_bathrooms' => ['sometimes', 'nullable', 'integer', 'min:0', 'gte:min_bathrooms'],
             'min_area' => ['sometimes', 'nullable', 'numeric', 'min:0'],
             'max_area' => ['sometimes', 'nullable', 'numeric', 'min:0', 'gte:min_area'],
+            'min_year_built' => ['sometimes', 'nullable', ...Property::yearBuiltRules()],
+            'max_year_built' => ['sometimes', 'nullable', ...Property::yearBuiltRules(), 'gte:min_year_built'],
             'property_type' => ['sometimes', 'nullable', 'string', 'max:40'],
             'property_category_id' => ['sometimes', 'nullable', 'integer', Rule::exists('real_estate_property_categories', 'id')->where('team_id', $teamId)],
             'property_template_id' => ['sometimes', 'nullable', 'integer', Rule::exists('real_estate_property_templates', 'id')->where('team_id', $teamId)],
@@ -71,6 +73,7 @@ final class PropertyController
             ->bedrooms($filters['min_bedrooms'] ?? null, $filters['max_bedrooms'] ?? null)
             ->bathrooms($filters['min_bathrooms'] ?? null, $filters['max_bathrooms'] ?? null)
             ->areaRange($filters['min_area'] ?? null, $filters['max_area'] ?? null)
+            ->yearBuiltRange($filters['min_year_built'] ?? null, $filters['max_year_built'] ?? null)
             ->propertyType($filters['property_type'] ?? null)
             ->category($filters['property_category_id'] ?? null)
             ->country($filters['country'] ?? null)
@@ -102,7 +105,7 @@ final class PropertyController
             'parking' => ['sometimes', 'array'],
             'gardens' => ['sometimes', 'array'],
             'area_sqft' => ['sometimes', 'nullable', 'numeric', 'min:0'],
-            'year_built' => ['sometimes', 'nullable', 'integer', 'min:1066', 'max:'.((int) now()->year + 2)],
+            'year_built' => ['sometimes', 'nullable', ...Property::yearBuiltRules()],
             'structured_address' => ['sometimes', 'array'],
             'latitude' => ['sometimes', 'nullable', 'numeric', 'between:-90,90'],
             'longitude' => ['sometimes', 'nullable', 'numeric', 'between:-180,180'],
@@ -205,7 +208,7 @@ final class PropertyController
             'parking' => ['sometimes', 'array'],
             'gardens' => ['sometimes', 'array'],
             'area_sqft' => ['sometimes', 'nullable', 'numeric', 'min:0'],
-            'year_built' => ['sometimes', 'nullable', 'integer', 'min:1066', 'max:'.((int) now()->year + 2)],
+            'year_built' => ['sometimes', 'nullable', ...Property::yearBuiltRules()],
             'structured_address' => ['sometimes', 'array'],
             'latitude' => ['sometimes', 'nullable', 'numeric', 'between:-90,90'],
             'longitude' => ['sometimes', 'nullable', 'numeric', 'between:-180,180'],

--- a/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
@@ -64,7 +64,11 @@ final class PropertyResource extends Resource
             TextInput::make('bathrooms')->numeric()->minValue(0),
             TextInput::make('reception_rooms')->numeric()->minValue(0),
             TextInput::make('area_sqft')->numeric()->minValue(0),
-            TextInput::make('year_built')->numeric()->minValue(1066)->maxValue((int) now()->year + 2),
+            TextInput::make('year_built')
+                ->numeric()
+                ->minValue(Property::EARLIEST_YEAR_BUILT)
+                ->maxValue(Property::latestYearBuilt())
+                ->helperText(Property::yearBuiltMessage()),
             Select::make('property_type')->options([
                 'residential' => 'Residential',
                 'house' => 'House',

--- a/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
@@ -9,6 +9,10 @@
         <input id="advanced-min-price" type="number" wire:model="minPrice" min="0">
         <label for="advanced-max-price">Maximum price</label>
         <input id="advanced-max-price" type="number" wire:model="maxPrice" min="0">
+        <label for="advanced-min-year-built">Earliest build year</label>
+        <input id="advanced-min-year-built" type="number" wire:model="minYearBuilt" min="{{ \Liberu\RealEstate\Properties\Models\Property::EARLIEST_YEAR_BUILT }}" max="{{ \Liberu\RealEstate\Properties\Models\Property::latestYearBuilt() }}">
+        <label for="advanced-max-year-built">Latest build year</label>
+        <input id="advanced-max-year-built" type="number" wire:model="maxYearBuilt" min="{{ \Liberu\RealEstate\Properties\Models\Property::EARLIEST_YEAR_BUILT }}" max="{{ \Liberu\RealEstate\Properties\Models\Property::latestYearBuilt() }}">
         <label for="advanced-property-type">Property type</label>
         <input id="advanced-property-type" type="text" wire:model="propertyType" maxlength="40">
         <label for="advanced-property-category">Category</label>

--- a/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
+++ b/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
@@ -39,6 +39,10 @@ final class AdvancedPropertySearch extends Component
 
     public ?float $maxArea = null;
 
+    public ?int $minYearBuilt = null;
+
+    public ?int $maxYearBuilt = null;
+
     public ?string $propertyType = null;
 
     public ?int $propertyCategoryId = null;
@@ -76,6 +80,8 @@ final class AdvancedPropertySearch extends Component
             'maxBathrooms' => ['nullable', 'integer', 'min:0', 'gte:minBathrooms'],
             'minArea' => ['nullable', 'numeric', 'min:0'],
             'maxArea' => ['nullable', 'numeric', 'min:0', 'gte:minArea'],
+            'minYearBuilt' => ['nullable', ...Property::yearBuiltRules()],
+            'maxYearBuilt' => ['nullable', ...Property::yearBuiltRules(), 'gte:minYearBuilt'],
             'propertyType' => ['nullable', 'string', 'max:40'],
             'propertyCategoryId' => ['nullable', 'integer', 'exists:real_estate_property_categories,id'],
             'propertyTemplateId' => ['nullable', 'integer', 'exists:real_estate_property_templates,id'],
@@ -109,6 +115,7 @@ final class AdvancedPropertySearch extends Component
                 ->bedrooms($this->minBedrooms, $this->maxBedrooms)
                 ->bathrooms($this->minBathrooms, $this->maxBathrooms)
                 ->areaRange($this->minArea, $this->maxArea)
+                ->yearBuiltRange($this->minYearBuilt, $this->maxYearBuilt)
                 ->propertyType($this->propertyType)
                 ->category($this->propertyCategoryId)
                 ->where('property_template_id', $this->propertyTemplateId)

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -17,6 +17,8 @@ final class Property extends Model
 {
     use SoftDeletes;
 
+    public const EARLIEST_YEAR_BUILT = 1066;
+
     protected $table = 'real_estate_properties';
 
     protected $guarded = ['id'];
@@ -58,6 +60,25 @@ final class Property extends Model
     public function setYearBuiltAttribute(mixed $value): void
     {
         $this->attributes['year_built'] = is_string($value) ? substr($value, 0, 4) : $value;
+    }
+
+    public static function latestYearBuilt(): int
+    {
+        return (int) now()->year + 2;
+    }
+
+    /** @return list<string> */
+    public static function yearBuiltRules(): array
+    {
+        return ['integer', 'min:'.self::EARLIEST_YEAR_BUILT, 'max:'.self::latestYearBuilt()];
+    }
+
+    public static function yearBuiltMessage(): string
+    {
+        return __('Enter a build year between :from and :to.', [
+            'from' => self::EARLIEST_YEAR_BUILT,
+            'to' => self::latestYearBuilt(),
+        ]);
     }
 
     public function history(): HasMany
@@ -232,6 +253,12 @@ final class Property extends Model
     {
         return $query->when($minimum !== null && $minimum !== '', fn (Builder $query): Builder => $query->where('area_sqft', '>=', $minimum))
             ->when($maximum !== null && $maximum !== '', fn (Builder $query): Builder => $query->where('area_sqft', '<=', $maximum));
+    }
+
+    public function scopeYearBuiltRange(Builder $query, mixed $minimum, mixed $maximum): Builder
+    {
+        return $query->when($minimum !== null && $minimum !== '', fn (Builder $query): Builder => $query->where('year_built', '>=', $minimum))
+            ->when($maximum !== null && $maximum !== '', fn (Builder $query): Builder => $query->where('year_built', '<=', $maximum));
     }
 
     public function scopePropertyType(Builder $query, ?string $type): Builder

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -229,6 +229,19 @@ it('preserves legacy property metadata and year normalization', function (): voi
         ->and($property->floor_plan_image)->toBe('https://example.test/floor-plan.png');
 });
 
+it('centralizes legacy build-year rules and filters properties by year range', function (): void {
+    $old = app(CreateProperty::class)->handle(10, 20, ['address' => '1 Old Street', 'year_built' => 1900]);
+    $new = app(CreateProperty::class)->handle(10, 20, ['address' => '2 New Street', 'year_built' => 2020]);
+    app(CreateProperty::class)->handle(10, 20, ['address' => '3 Other Street', 'year_built' => 2025]);
+
+    expect(Property::EARLIEST_YEAR_BUILT)->toBe(1066)
+        ->and(Property::latestYearBuilt())->toBe((int) now()->year + 2)
+        ->and(Property::yearBuiltRules())->toBe(['integer', 'min:1066', 'max:'.((int) now()->year + 2)])
+        ->and(Property::yearBuiltMessage())->toContain('1066')
+        ->and(Property::query()->forTeam(10)->yearBuiltRange(1901, 2021)->pluck('id')->all())->toBe([$new->getKey()])
+        ->and($old->year_built)->toBe(1900);
+});
+
 it('supports tenant and user-scoped property favorites', function (): void {
     $property = app(CreateProperty::class)->handle(10, 20, ['address' => '1 High Street']);
     $otherUserProperty = app(CreateProperty::class)->handle(10, 21, ['address' => '2 High Street']);


### PR DESCRIPTION
Carries the old property build-year contract into the modular core model and keeps API, Livewire, and Filament behavior aligned. Adds dynamic validation bounds, a reusable year-range scope, and coverage for the shared rules and filtering.