### PR TITLE
Restore legacy property score filters

### DIFF
--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -80,10 +80,10 @@ final class PropertyController
             ->energyRating($filters['energy_rating'] ?? null)
             ->when($filters['featured'] ?? false, fn ($query) => $query->featured())
             ->when($filters['favorites_only'] ?? false, fn ($query) => $query->favoritedBy($teamId, $request->user()->getAuthIdentifier()))
-            ->minimumScore('energy_score', $filters['min_energy_score'] ?? null)
-            ->minimumScore('walkability_score', $filters['min_walkability_score'] ?? null)
-            ->minimumScore('transit_score', $filters['min_transit_score'] ?? null)
-            ->minimumScore('bike_score', $filters['min_bike_score'] ?? null);
+            ->minEnergyScore($filters['min_energy_score'] ?? null)
+            ->walkabilityScore($filters['min_walkability_score'] ?? null)
+            ->transitScore($filters['min_transit_score'] ?? null)
+            ->bikeScore($filters['min_bike_score'] ?? null);
 
         return PropertyResource::collection($query->latest()->paginate($pageSize)->withQueryString())->response();
     }

--- a/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
@@ -19,6 +19,7 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Notifications\Notification;
+use Filament\Tables\Filters\Filter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Liberu\RealEstate\Core\Models\Branch;
@@ -120,6 +121,20 @@ final class PropertyResource extends Resource
                 TextColumn::make('property_type')->label('Type')->searchable(),
                 TextColumn::make('status')->badge(),
                 TextColumn::make('created_at')->dateTime()->sortable(),
+            ])
+            ->filters([
+                Filter::make('minimum_scores')
+                    ->form([
+                        TextInput::make('energy_score')->numeric()->minValue(0)->maxValue(100),
+                        TextInput::make('walkability_score')->numeric()->minValue(0)->maxValue(100),
+                        TextInput::make('transit_score')->numeric()->minValue(0)->maxValue(100),
+                        TextInput::make('bike_score')->numeric()->minValue(0)->maxValue(100),
+                    ])
+                    ->query(fn (Builder $query, array $data): Builder => $query
+                        ->minEnergyScore($data['energy_score'] ?? null)
+                        ->walkabilityScore($data['walkability_score'] ?? null)
+                        ->transitScore($data['transit_score'] ?? null)
+                        ->bikeScore($data['bike_score'] ?? null)),
             ])
             ->recordActions([
                 EditAction::make(),

--- a/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
@@ -13,6 +13,14 @@
         <input id="advanced-min-year-built" type="number" wire:model="minYearBuilt" min="{{ \Liberu\RealEstate\Properties\Models\Property::EARLIEST_YEAR_BUILT }}" max="{{ \Liberu\RealEstate\Properties\Models\Property::latestYearBuilt() }}">
         <label for="advanced-max-year-built">Latest build year</label>
         <input id="advanced-max-year-built" type="number" wire:model="maxYearBuilt" min="{{ \Liberu\RealEstate\Properties\Models\Property::EARLIEST_YEAR_BUILT }}" max="{{ \Liberu\RealEstate\Properties\Models\Property::latestYearBuilt() }}">
+        <label for="advanced-min-energy-score">Minimum energy score</label>
+        <input id="advanced-min-energy-score" type="number" wire:model="minEnergyScore" min="0" max="100">
+        <label for="advanced-min-walkability-score">Minimum walkability score</label>
+        <input id="advanced-min-walkability-score" type="number" wire:model="minWalkabilityScore" min="0" max="100">
+        <label for="advanced-min-transit-score">Minimum transit score</label>
+        <input id="advanced-min-transit-score" type="number" wire:model="minTransitScore" min="0" max="100">
+        <label for="advanced-min-bike-score">Minimum bike score</label>
+        <input id="advanced-min-bike-score" type="number" wire:model="minBikeScore" min="0" max="100">
         <label for="advanced-property-type">Property type</label>
         <select id="advanced-property-type" wire:model="propertyType">
             <option value="">Any property type</option>

--- a/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
@@ -22,6 +22,14 @@
     <input id="min-price" type="number" wire:model.live="minPrice" min="0">
     <label for="max-price">Maximum price</label>
     <input id="max-price" type="number" wire:model.live="maxPrice" min="0">
+    <label for="min-energy-score">Minimum energy score</label>
+    <input id="min-energy-score" type="number" wire:model.live="minEnergyScore" min="0" max="100">
+    <label for="min-walkability-score">Minimum walkability score</label>
+    <input id="min-walkability-score" type="number" wire:model.live="minWalkabilityScore" min="0" max="100">
+    <label for="min-transit-score">Minimum transit score</label>
+    <input id="min-transit-score" type="number" wire:model.live="minTransitScore" min="0" max="100">
+    <label for="min-bike-score">Minimum bike score</label>
+    <input id="min-bike-score" type="number" wire:model.live="minBikeScore" min="0" max="100">
     <label for="featured-only">
         <input id="featured-only" type="checkbox" wire:model.live="featuredOnly">
         Featured only

--- a/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
+++ b/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
@@ -53,6 +53,14 @@ final class AdvancedPropertySearch extends Component
 
     public ?string $energyRating = null;
 
+    public ?int $minEnergyScore = null;
+
+    public ?int $minWalkabilityScore = null;
+
+    public ?int $minTransitScore = null;
+
+    public ?int $minBikeScore = null;
+
     /** @var array<int, string> */
     public array $selectedAmenities = [];
 
@@ -88,6 +96,10 @@ final class AdvancedPropertySearch extends Component
             'postalCode' => ['nullable', 'string', 'max:20'],
             'country' => ['nullable', 'string', 'size:2'],
             'energyRating' => ['nullable', 'string', 'max:10'],
+            'minEnergyScore' => ['nullable', 'integer', 'between:0,100'],
+            'minWalkabilityScore' => ['nullable', 'integer', 'between:0,100'],
+            'minTransitScore' => ['nullable', 'integer', 'between:0,100'],
+            'minBikeScore' => ['nullable', 'integer', 'between:0,100'],
             'selectedAmenities' => ['array', 'max:20'],
             'selectedAmenities.*' => ['string', 'max:80'],
             'latitude' => ['nullable', 'numeric', 'between:-90,90'],
@@ -122,6 +134,10 @@ final class AdvancedPropertySearch extends Component
                 ->where('property_template_id', $this->propertyTemplateId)
                 ->country($this->country)
                 ->energyRating($this->energyRating)
+                ->minEnergyScore($this->minEnergyScore)
+                ->walkabilityScore($this->minWalkabilityScore)
+                ->transitScore($this->minTransitScore)
+                ->bikeScore($this->minBikeScore)
                 ->hasAmenities($this->selectedAmenities)
                 ->when($this->latitude !== null && $this->longitude !== null && $this->radius !== null, fn ($query) => $query->nearby($this->latitude, $this->longitude, $this->radius))
                 ->when($this->featuredOnly, fn ($query) => $query->featured())

--- a/modules/real-estate-properties-livewire/src/Components/PropertyList.php
+++ b/modules/real-estate-properties-livewire/src/Components/PropertyList.php
@@ -38,6 +38,14 @@ final class PropertyList extends Component
 
     public bool $featuredOnly = false;
 
+    public ?int $minEnergyScore = null;
+
+    public ?int $minWalkabilityScore = null;
+
+    public ?int $minTransitScore = null;
+
+    public ?int $minBikeScore = null;
+
     /** @var array<int, array<string, mixed>> */
     public array $similarProperties = [];
 
@@ -112,6 +120,10 @@ final class PropertyList extends Component
                 ->priceRange($this->minPrice, $this->maxPrice)
                 ->bedrooms($this->minBedrooms, $this->maxBedrooms)
                 ->propertyType($this->propertyType)
+                ->minEnergyScore($this->minEnergyScore)
+                ->walkabilityScore($this->minWalkabilityScore)
+                ->transitScore($this->minTransitScore)
+                ->bikeScore($this->minBikeScore)
                 ->when($this->featuredOnly, fn ($query) => $query->featured())
                 ->latest()->paginate(20);
 

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -334,6 +334,26 @@ final class Property extends Model
         return $query->when($minimum !== null && $minimum !== '', fn (Builder $query): Builder => $query->where($column, '>=', $minimum));
     }
 
+    public function scopeMinEnergyScore(Builder $query, mixed $minimum): Builder
+    {
+        return $query->minimumScore('energy_score', $minimum);
+    }
+
+    public function scopeWalkabilityScore(Builder $query, mixed $minimum): Builder
+    {
+        return $query->minimumScore('walkability_score', $minimum);
+    }
+
+    public function scopeTransitScore(Builder $query, mixed $minimum): Builder
+    {
+        return $query->minimumScore('transit_score', $minimum);
+    }
+
+    public function scopeBikeScore(Builder $query, mixed $minimum): Builder
+    {
+        return $query->minimumScore('bike_score', $minimum);
+    }
+
     public function scopeFeatured(Builder $query): Builder
     {
         return $query->where('is_featured', true);

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -139,6 +139,28 @@ it('centralizes property types and matches their stored casing consistently', fu
         ->and(Property::query()->forTeam(10)->propertyType('HOUSE')->pluck('id')->all())->toBe([$house->getKey()]);
 });
 
+it('preserves the legacy named property score scopes', function (): void {
+    $matching = app(CreateProperty::class)->handle(10, 20, [
+        'address' => '1 High Street',
+        'energy_score' => 90,
+        'walkability_score' => 80,
+        'transit_score' => 70,
+        'bike_score' => 60,
+    ]);
+    app(CreateProperty::class)->handle(10, 20, [
+        'address' => '2 Low Street',
+        'energy_score' => 50,
+        'walkability_score' => 50,
+        'transit_score' => 50,
+        'bike_score' => 50,
+    ]);
+
+    expect(Property::query()->forTeam(10)->minEnergyScore(90)->pluck('id')->all())->toBe([$matching->getKey()])
+        ->and(Property::query()->forTeam(10)->walkabilityScore(80)->pluck('id')->all())->toBe([$matching->getKey()])
+        ->and(Property::query()->forTeam(10)->transitScore(70)->pluck('id')->all())->toBe([$matching->getKey()])
+        ->and(Property::query()->forTeam(10)->bikeScore(60)->pluck('id')->all())->toBe([$matching->getKey()]);
+});
+
 it('supports legacy postal-prefix and stale-sync listing filters', function () {
     $stale = app(CreateProperty::class)->handle(10, 20, [
         'address' => '1 High Street',


### PR DESCRIPTION
Restores the old named property score scopes and exposes minimum energy, walkability, transit, and bike score filtering across the core model, API, Livewire, and Filament surfaces. Includes focused coverage.