### PR TITLE
Add property status filtering

### DIFF
--- a/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
+++ b/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
@@ -13,6 +13,7 @@ paths:
         - {name: latitude, in: query, schema: {type: number, minimum: -90, maximum: 90}}
         - {name: longitude, in: query, schema: {type: number, minimum: -180, maximum: 180}}
         - {name: radius, in: query, schema: {type: number, exclusiveMinimum: 0, maximum: 500, description: Radius in kilometres}}
+        - {name: status, in: query, schema: {type: string, enum: [draft, available, under_offer, sold, let, withdrawn]}}
         - {name: amenities[], in: query, style: form, explode: true, schema: {type: array, maxItems: 20, items: {type: string, maxLength: 80}}}
       responses:
         '200': {description: Authorized paginated properties}

--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -54,6 +54,7 @@ final class PropertyController
             'property_template_id' => ['sometimes', 'nullable', 'integer', Rule::exists('real_estate_property_templates', 'id')->where('team_id', $teamId)],
             'country' => ['sometimes', 'nullable', 'string', 'size:2'],
             'energy_rating' => ['sometimes', 'nullable', 'string', 'max:10'],
+            'status' => ['sometimes', 'nullable', Rule::enum(PropertyStatus::class)],
             'featured' => ['sometimes', 'boolean'],
             'favorites_only' => ['sometimes', 'boolean'],
             'min_energy_score' => ['sometimes', 'nullable', 'integer', 'between:0,100'],
@@ -78,6 +79,7 @@ final class PropertyController
             ->category($filters['property_category_id'] ?? null)
             ->country($filters['country'] ?? null)
             ->energyRating($filters['energy_rating'] ?? null)
+            ->status($filters['status'] ?? null)
             ->when($filters['featured'] ?? false, fn ($query) => $query->featured())
             ->when($filters['favorites_only'] ?? false, fn ($query) => $query->favoritedBy($teamId, $request->user()->getAuthIdentifier()))
             ->minEnergyScore($filters['min_energy_score'] ?? null)

--- a/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
@@ -20,6 +20,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Notifications\Notification;
 use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Liberu\RealEstate\Core\Models\Branch;
@@ -123,6 +124,7 @@ final class PropertyResource extends Resource
                 TextColumn::make('created_at')->dateTime()->sortable(),
             ])
             ->filters([
+                SelectFilter::make('status')->options(collect(PropertyStatus::cases())->mapWithKeys(fn (PropertyStatus $status): array => [$status->value => str($status->value)->headline()->toString()])->all()),
                 Filter::make('minimum_scores')
                     ->form([
                         TextInput::make('energy_score')->numeric()->minValue(0)->maxValue(100),

--- a/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
@@ -28,6 +28,13 @@
                 <option value="{{ $type }}">{{ $label }}</option>
             @endforeach
         </select>
+        <label for="advanced-status">Status</label>
+        <select id="advanced-status" wire:model="status">
+            <option value="">Any status</option>
+            @foreach (['draft' => 'Draft', 'available' => 'Available', 'under_offer' => 'Under offer', 'sold' => 'Sold', 'let' => 'Let', 'withdrawn' => 'Withdrawn'] as $value => $label)
+                <option value="{{ $value }}">{{ $label }}</option>
+            @endforeach
+        </select>
         <label for="advanced-property-category">Category</label>
         <select id="advanced-property-category" wire:model="propertyCategoryId">
             <option value="">Any category</option>

--- a/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
@@ -18,6 +18,13 @@
             <option value="{{ $type }}">{{ $label }}</option>
         @endforeach
     </select>
+    <label for="property-status">Status</label>
+    <select id="property-status" wire:model.live="status">
+        <option value="">Any status</option>
+        @foreach (['draft' => 'Draft', 'available' => 'Available', 'under_offer' => 'Under offer', 'sold' => 'Sold', 'let' => 'Let', 'withdrawn' => 'Withdrawn'] as $value => $label)
+            <option value="{{ $value }}">{{ $label }}</option>
+        @endforeach
+    </select>
     <label for="min-price">Minimum price</label>
     <input id="min-price" type="number" wire:model.live="minPrice" min="0">
     <label for="max-price">Maximum price</label>

--- a/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
+++ b/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
@@ -45,6 +45,8 @@ final class AdvancedPropertySearch extends Component
 
     public ?string $propertyType = null;
 
+    public ?string $status = null;
+
     public ?int $propertyCategoryId = null;
 
     public ?int $propertyTemplateId = null;
@@ -91,6 +93,7 @@ final class AdvancedPropertySearch extends Component
             'minYearBuilt' => ['nullable', ...Property::yearBuiltRules()],
             'maxYearBuilt' => ['nullable', ...Property::yearBuiltRules(), 'gte:minYearBuilt'],
             'propertyType' => ['nullable', 'string', 'max:40'],
+            'status' => ['nullable', 'string', 'in:draft,available,under_offer,sold,let,withdrawn'],
             'propertyCategoryId' => ['nullable', 'integer', 'exists:real_estate_property_categories,id'],
             'propertyTemplateId' => ['nullable', 'integer', 'exists:real_estate_property_templates,id'],
             'postalCode' => ['nullable', 'string', 'max:20'],
@@ -130,6 +133,7 @@ final class AdvancedPropertySearch extends Component
                 ->areaRange($this->minArea, $this->maxArea)
                 ->yearBuiltRange($this->minYearBuilt, $this->maxYearBuilt)
                 ->propertyType($this->propertyType)
+                ->status($this->status)
                 ->category($this->propertyCategoryId)
                 ->where('property_template_id', $this->propertyTemplateId)
                 ->country($this->country)

--- a/modules/real-estate-properties-livewire/src/Components/PropertyList.php
+++ b/modules/real-estate-properties-livewire/src/Components/PropertyList.php
@@ -28,6 +28,8 @@ final class PropertyList extends Component
 
     public ?string $propertyType = null;
 
+    public ?string $status = null;
+
     public ?float $minPrice = null;
 
     public ?float $maxPrice = null;
@@ -142,6 +144,7 @@ final class PropertyList extends Component
                 ->areaRange($this->minArea, $this->maxArea)
                 ->yearBuiltRange($this->minYearBuilt, $this->maxYearBuilt)
                 ->propertyType($this->propertyType)
+                ->status($this->status)
                 ->hasAmenities($this->selectedAmenities)
                 ->country($this->country)
                 ->energyRating($this->energyRating)

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -327,6 +327,13 @@ final class Property extends Model
         return $query->when(filled($rating), fn (Builder $query): Builder => $query->where('energy_rating', strtoupper((string) $rating)));
     }
 
+    public function scopeStatus(Builder $query, PropertyStatus|string|null $status): Builder
+    {
+        $value = $status instanceof PropertyStatus ? $status->value : $status;
+
+        return $query->when(filled($value), fn (Builder $query): Builder => $query->where('status', $value));
+    }
+
     public function scopeMinimumScore(Builder $query, string $column, mixed $minimum): Builder
     {
         abort_unless(in_array($column, ['energy_score', 'walkability_score', 'transit_score', 'bike_score'], true), 400);

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -279,6 +279,16 @@ it('centralizes legacy build-year rules and filters properties by year range', f
         ->and($old->year_built)->toBe(1900);
 });
 
+it('filters properties by the modular lifecycle status vocabulary', function (): void {
+    $draft = app(CreateProperty::class)->handle(10, 20, ['address' => '1 Draft Street']);
+    $available = app(CreateProperty::class)->handle(10, 20, ['address' => '2 Available Street']);
+    app(TransitionProperty::class)->handle(10, 20, $available->getKey(), PropertyStatus::Available);
+
+    expect(Property::query()->forTeam(10)->status(PropertyStatus::Draft)->pluck('id')->all())->toBe([$draft->getKey()])
+        ->and(Property::query()->forTeam(10)->status('available')->pluck('id')->all())->toBe([$available->getKey()])
+        ->and(Property::query()->forTeam(10)->status(null)->count())->toBe(2);
+});
+
 it('supports tenant and user-scoped property favorites', function (): void {
     $property = app(CreateProperty::class)->handle(10, 20, ['address' => '1 High Street']);
     $otherUserProperty = app(CreateProperty::class)->handle(10, 21, ['address' => '2 High Street']);


### PR DESCRIPTION
Adds a shared lifecycle status scope and exposes status filtering across the property API/OpenAPI contract, both Livewire search surfaces, and the Filament resource. Includes focused coverage and synchronized standalone module PRs.