### PR TITLE
Add bounded property ordering across module surfaces

### DIFF
--- a/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
+++ b/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
@@ -14,6 +14,8 @@ paths:
         - {name: longitude, in: query, schema: {type: number, minimum: -180, maximum: 180}}
         - {name: radius, in: query, schema: {type: number, exclusiveMinimum: 0, maximum: 500, description: Radius in kilometres}}
         - {name: status, in: query, schema: {type: string, enum: [draft, available, under_offer, sold, let, withdrawn]}}
+        - {name: sort_by, in: query, schema: {type: string, enum: [created_at, updated_at, price, year_built, bedrooms, bathrooms, area_sqft, address]}}
+        - {name: sort_direction, in: query, schema: {type: string, enum: [asc, desc], default: desc}}
         - {name: amenities[], in: query, style: form, explode: true, schema: {type: array, maxItems: 20, items: {type: string, maxLength: 80}}}
       responses:
         '200': {description: Authorized paginated properties}

--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -55,6 +55,8 @@ final class PropertyController
             'country' => ['sometimes', 'nullable', 'string', 'size:2'],
             'energy_rating' => ['sometimes', 'nullable', 'string', 'max:10'],
             'status' => ['sometimes', 'nullable', Rule::enum(PropertyStatus::class)],
+            'sort_by' => ['sometimes', 'nullable', Rule::in(Property::SORTABLE_COLUMNS)],
+            'sort_direction' => ['sometimes', 'nullable', Rule::in(['asc', 'desc'])],
             'featured' => ['sometimes', 'boolean'],
             'favorites_only' => ['sometimes', 'boolean'],
             'min_energy_score' => ['sometimes', 'nullable', 'integer', 'between:0,100'],
@@ -87,7 +89,7 @@ final class PropertyController
             ->transitScore($filters['min_transit_score'] ?? null)
             ->bikeScore($filters['min_bike_score'] ?? null);
 
-        return PropertyResource::collection($query->latest()->paginate($pageSize)->withQueryString())->response();
+        return PropertyResource::collection($query->sorted($filters['sort_by'] ?? null, $filters['sort_direction'] ?? 'desc')->paginate($pageSize)->withQueryString())->response();
     }
 
     public function store(Request $request, CreateProperty $create): JsonResponse

--- a/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
@@ -118,9 +118,14 @@ final class PropertyResource extends Resource
                 return $teamId === null ? $query->whereRaw('1 = 0') : $query->forTeam($teamId);
             })
             ->columns([
-                TextColumn::make('address')->searchable()->wrap(),
-                TextColumn::make('property_type')->label('Type')->searchable(),
+                TextColumn::make('address')->searchable()->sortable()->wrap(),
+                TextColumn::make('property_type')->label('Type')->searchable()->sortable(),
                 TextColumn::make('status')->badge(),
+                TextColumn::make('price')->numeric()->sortable(),
+                TextColumn::make('bedrooms')->sortable(),
+                TextColumn::make('bathrooms')->sortable(),
+                TextColumn::make('area_sqft')->sortable(),
+                TextColumn::make('year_built')->sortable(),
                 TextColumn::make('created_at')->dateTime()->sortable(),
             ])
             ->filters([

--- a/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/property-list.blade.php
@@ -39,6 +39,17 @@
             <option value="{{ $value }}">{{ $label }}</option>
         @endforeach
     </select>
+    <label for="property-sort-by">Sort by</label>
+    <select id="property-sort-by" wire:model.live="sortBy">
+        @foreach (['created_at' => 'Newest', 'updated_at' => 'Recently updated', 'price' => 'Price', 'year_built' => 'Year built', 'bedrooms' => 'Bedrooms', 'bathrooms' => 'Bathrooms', 'area_sqft' => 'Area', 'address' => 'Address'] as $value => $label)
+            <option value="{{ $value }}">{{ $label }}</option>
+        @endforeach
+    </select>
+    <label for="property-sort-direction">Direction</label>
+    <select id="property-sort-direction" wire:model.live="sortDirection">
+        <option value="desc">Descending</option>
+        <option value="asc">Ascending</option>
+    </select>
     <label for="min-price">Minimum price</label>
     <input id="min-price" type="number" wire:model.live="minPrice" min="0">
     <label for="max-price">Maximum price</label>

--- a/modules/real-estate-properties-livewire/src/Components/PropertyList.php
+++ b/modules/real-estate-properties-livewire/src/Components/PropertyList.php
@@ -31,6 +31,10 @@ final class PropertyList extends Component
 
     public ?string $status = null;
 
+    public string $sortBy = 'created_at';
+
+    public string $sortDirection = 'desc';
+
     public ?float $minPrice = null;
 
     public ?float $maxPrice = null;
@@ -135,7 +139,7 @@ final class PropertyList extends Component
         $propertyTypes = Property::TYPES;
         $properties = $teamId === null
             ? collect()
-            : $this->buildQuery()->latest()->paginate(20);
+            : $this->buildQuery()->sorted($this->sortBy, $this->sortDirection)->paginate(20);
 
         return view('real-estate-properties-livewire::property-list', ['properties' => $properties, 'propertyTypes' => $propertyTypes]);
     }

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -34,6 +34,9 @@ final class Property extends Model
         'hmo' => 'HMO',
     ];
 
+    /** @var list<string> */
+    public const SORTABLE_COLUMNS = ['created_at', 'updated_at', 'price', 'year_built', 'bedrooms', 'bathrooms', 'area_sqft', 'address'];
+
     protected $table = 'real_estate_properties';
 
     protected $guarded = ['id'];
@@ -332,6 +335,14 @@ final class Property extends Model
         $value = $status instanceof PropertyStatus ? $status->value : $status;
 
         return $query->when(filled($value), fn (Builder $query): Builder => $query->where('status', $value));
+    }
+
+    public function scopeSorted(Builder $query, ?string $column, ?string $direction = 'desc'): Builder
+    {
+        $column = in_array($column, self::SORTABLE_COLUMNS, true) ? $column : 'created_at';
+        $direction = strtolower((string) $direction) === 'asc' ? 'asc' : 'desc';
+
+        return $query->orderBy($column, $direction);
     }
 
     public function scopeMinimumScore(Builder $query, string $column, mixed $minimum): Builder

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -289,6 +289,14 @@ it('filters properties by the modular lifecycle status vocabulary', function ():
         ->and(Property::query()->forTeam(10)->status(null)->count())->toBe(2);
 });
 
+it('provides bounded property ordering for every listing surface', function (): void {
+    $expensive = app(CreateProperty::class)->handle(10, 20, ['address' => 'Z Street', 'price' => 500000]);
+    $affordable = app(CreateProperty::class)->handle(10, 20, ['address' => 'A Street', 'price' => 100000]);
+
+    expect(Property::query()->forTeam(10)->sorted('price', 'asc')->pluck('id')->all())->toBe([$affordable->getKey(), $expensive->getKey()])
+        ->and(Property::query()->forTeam(10)->sorted('not_allowed', 'asc')->pluck('id')->all())->toBe([$expensive->getKey(), $affordable->getKey()]);
+});
+
 it('supports tenant and user-scoped property favorites', function (): void {
     $property = app(CreateProperty::class)->handle(10, 20, ['address' => '1 High Street']);
     $otherUserProperty = app(CreateProperty::class)->handle(10, 21, ['address' => '2 High Street']);


### PR DESCRIPTION
## Summary
- centralize the supported property sort columns and direction handling
- expose validated API ordering parameters and OpenAPI documentation
- add Livewire and Filament ordering controls
- cover bounded ordering behavior in the feature suite

## Verification
- vendor/bin/pest
- 286 passed, 12 skipped, 1442 assertions