### PR TITLE
Restore advanced property search ordering

### DIFF
--- a/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php
@@ -35,6 +35,17 @@
                 <option value="{{ $value }}">{{ $label }}</option>
             @endforeach
         </select>
+        <label for="advanced-sort-by">Sort by</label>
+        <select id="advanced-sort-by" wire:model.live="sortBy">
+            @foreach (['created_at' => 'Newest', 'updated_at' => 'Recently updated', 'price' => 'Price', 'year_built' => 'Year built', 'bedrooms' => 'Bedrooms', 'bathrooms' => 'Bathrooms', 'area_sqft' => 'Area', 'address' => 'Address'] as $value => $label)
+                <option value="{{ $value }}">{{ $label }}</option>
+            @endforeach
+        </select>
+        <label for="advanced-sort-direction">Sort direction</label>
+        <select id="advanced-sort-direction" wire:model.live="sortDirection">
+            <option value="desc">Descending</option>
+            <option value="asc">Ascending</option>
+        </select>
         <label for="advanced-property-category">Category</label>
         <select id="advanced-property-category" wire:model="propertyCategoryId">
             <option value="">Any category</option>

--- a/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
+++ b/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
@@ -47,6 +47,10 @@ final class AdvancedPropertySearch extends Component
 
     public ?string $status = null;
 
+    public string $sortBy = 'created_at';
+
+    public string $sortDirection = 'desc';
+
     public ?int $propertyCategoryId = null;
 
     public ?int $propertyTemplateId = null;
@@ -94,6 +98,8 @@ final class AdvancedPropertySearch extends Component
             'maxYearBuilt' => ['nullable', ...Property::yearBuiltRules(), 'gte:minYearBuilt'],
             'propertyType' => ['nullable', 'string', 'max:40'],
             'status' => ['nullable', 'string', 'in:draft,available,under_offer,sold,let,withdrawn'],
+            'sortBy' => ['required', 'string', 'in:created_at,updated_at,price,year_built,bedrooms,bathrooms,area_sqft,address'],
+            'sortDirection' => ['required', 'string', 'in:asc,desc'],
             'propertyCategoryId' => ['nullable', 'integer', 'exists:real_estate_property_categories,id'],
             'propertyTemplateId' => ['nullable', 'integer', 'exists:real_estate_property_templates,id'],
             'postalCode' => ['nullable', 'string', 'max:20'],
@@ -145,7 +151,7 @@ final class AdvancedPropertySearch extends Component
                 ->hasAmenities($this->selectedAmenities)
                 ->when($this->latitude !== null && $this->longitude !== null && $this->radius !== null, fn ($query) => $query->nearby($this->latitude, $this->longitude, $this->radius))
                 ->when($this->featuredOnly, fn ($query) => $query->featured())
-                ->latest()->paginate(12);
+                ->sorted($this->sortBy, $this->sortDirection)->paginate(12);
 
         return view('real-estate-properties-livewire::advanced-property-search', compact('properties', 'categories', 'templates', 'propertyTypes'));
     }

--- a/tests/Architecture/RealEstateCapabilityCoverageTest.php
+++ b/tests/Architecture/RealEstateCapabilityCoverageTest.php
@@ -107,6 +107,17 @@ it('keeps Livewire list surfaces validated and stateful', function (): void {
     }
 });
 
+it('keeps advanced Livewire search ordering bounded', function (): void {
+    $source = file_get_contents(base_path('modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php'));
+    $view = file_get_contents(base_path('modules/real-estate-properties-livewire/resources/views/advanced-property-search.blade.php'));
+
+    expect($source)->toContain('public string $sortBy = \'created_at\';')
+        ->toContain("'sortBy' => ['required', 'string', 'in:created_at,updated_at,price,year_built,bedrooms,bathrooms,area_sqft,address']")
+        ->toContain('->sorted($this->sortBy, $this->sortDirection)')
+        ->and($view)->toContain('advanced-sort-by')
+        ->toContain('advanced-sort-direction');
+});
+
 it('keeps Filament resources tenant-scoped and lifecycle-delegated', function (): void {
     $root = dirname(__DIR__, 2);
 


### PR DESCRIPTION
## Summary
- restore legacy sort-by and sort-direction state to advanced Livewire property search
- validate ordering inputs against the shared bounded property sort vocabulary
- add advanced search ordering controls and architecture coverage

## Verification
- vendor/bin/pest
- 287 passed, 12 skipped, 1447 assertions