### PR TITLE
Preserve property filters in Livewire URLs

### DIFF
--- a/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
+++ b/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
@@ -16,6 +16,22 @@ final class AdvancedPropertySearch extends Component
 {
     use WithPagination;
 
+    protected $queryString = [
+        'search' => ['except' => ''],
+        'minPrice' => ['except' => null],
+        'maxPrice' => ['except' => null],
+        'minBedrooms' => ['except' => null],
+        'propertyType' => ['except' => null],
+        'sortBy' => ['except' => 'created_at'],
+        'energyRating' => ['except' => null],
+        'minEnergyScore' => ['except' => null],
+        'minWalkabilityScore' => ['except' => null],
+        'minTransitScore' => ['except' => null],
+        'minBikeScore' => ['except' => null],
+        'featuredOnly' => ['except' => false],
+        'country' => ['except' => null],
+    ];
+
     #[Validate('nullable|string|max:255')]
     public string $search = '';
 

--- a/modules/real-estate-properties-livewire/src/Components/PropertyList.php
+++ b/modules/real-estate-properties-livewire/src/Components/PropertyList.php
@@ -20,6 +20,31 @@ final class PropertyList extends Component
 {
     use WithPagination;
 
+    protected $queryString = [
+        'search' => ['except' => ''],
+        'minPrice' => ['except' => null],
+        'maxPrice' => ['except' => null],
+        'minBedrooms' => ['except' => null],
+        'maxBedrooms' => ['except' => null],
+        'minBathrooms' => ['except' => null],
+        'maxBathrooms' => ['except' => null],
+        'minArea' => ['except' => null],
+        'maxArea' => ['except' => null],
+        'propertyType' => ['except' => null],
+        'selectedAmenities' => ['except' => []],
+        'status' => ['except' => null],
+        'sortBy' => ['except' => 'created_at'],
+        'sortDirection' => ['except' => 'desc'],
+        'country' => ['except' => null],
+        'energyRating' => ['except' => null],
+        'minEnergyScore' => ['except' => null],
+        'minWalkabilityScore' => ['except' => null],
+        'minTransitScore' => ['except' => null],
+        'minBikeScore' => ['except' => null],
+        'featuredOnly' => ['except' => false],
+        'needsSyncingOnly' => ['except' => false],
+    ];
+
     #[Validate('nullable|string|max:255')]
     public string $search = '';
 

--- a/tests/Architecture/RealEstateCapabilityCoverageTest.php
+++ b/tests/Architecture/RealEstateCapabilityCoverageTest.php
@@ -118,6 +118,18 @@ it('keeps advanced Livewire search ordering bounded', function (): void {
         ->toContain('advanced-sort-direction');
 });
 
+it('preserves Livewire property filters in the URL', function (): void {
+    $propertyList = file_get_contents(base_path('modules/real-estate-properties-livewire/src/Components/PropertyList.php'));
+    $advancedSearch = file_get_contents(base_path('modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php'));
+
+    expect($propertyList)->toContain('protected $queryString = [')
+        ->toContain("'selectedAmenities' => ['except' => []]")
+        ->toContain("'sortDirection' => ['except' => 'desc']")
+        ->and($advancedSearch)->toContain('protected $queryString = [')
+        ->toContain("'sortBy' => ['except' => 'created_at']")
+        ->toContain("'featuredOnly' => ['except' => false]");
+});
+
 it('keeps Filament resources tenant-scoped and lifecycle-delegated', function (): void {
     $root = dirname(__DIR__, 2);
 


### PR DESCRIPTION
## Summary
- preserve filter and sort state in the URL for both property Livewire surfaces
- keep default values out of generated query strings
- retain team-scoped filtering behavior across refreshes and navigation

## Verification
- vendor/bin/pest
- 288 passed, 12 skipped, 1453 assertions