### PR TITLE
Respect optional advanced search templates

### DIFF
--- a/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
+++ b/modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php
@@ -157,7 +157,7 @@ final class AdvancedPropertySearch extends Component
                 ->propertyType($this->propertyType)
                 ->status($this->status)
                 ->category($this->propertyCategoryId)
-                ->where('property_template_id', $this->propertyTemplateId)
+                ->when($this->propertyTemplateId !== null, fn ($query) => $query->where('property_template_id', $this->propertyTemplateId))
                 ->country($this->country)
                 ->energyRating($this->energyRating)
                 ->minEnergyScore($this->minEnergyScore)

--- a/tests/Architecture/RealEstateCapabilityCoverageTest.php
+++ b/tests/Architecture/RealEstateCapabilityCoverageTest.php
@@ -143,6 +143,12 @@ it('keeps the API property response aligned with legacy listing data', function 
         ->toContain("#/components/schemas/PropertyResponse");
 });
 
+it('does not narrow advanced Livewire search when no template is selected', function (): void {
+    $source = file_get_contents(base_path('modules/real-estate-properties-livewire/src/Components/AdvancedPropertySearch.php'));
+
+    expect($source)->toContain('->when($this->propertyTemplateId !== null, fn ($query) => $query->where(\'property_template_id\', $this->propertyTemplateId))');
+});
+
 it('keeps Filament resources tenant-scoped and lifecycle-delegated', function (): void {
     $root = dirname(__DIR__, 2);
 


### PR DESCRIPTION
## Summary
- apply the advanced property template filter only when a template is selected
- prevent the default null template state from hiding untargeted properties
- add regression coverage for the guarded query

## Verification
- vendor/bin/pest
- 290 passed, 12 skipped, 1484 assertions