### PR TITLE
Filter properties by template across surfaces

### DIFF
--- a/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
+++ b/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
@@ -14,6 +14,7 @@ paths:
         - {name: longitude, in: query, schema: {type: number, minimum: -180, maximum: 180}}
         - {name: radius, in: query, schema: {type: number, exclusiveMinimum: 0, maximum: 500, description: Radius in kilometres}}
         - {name: status, in: query, schema: {type: string, enum: [draft, available, under_offer, sold, let, withdrawn]}}
+        - {name: property_template_id, in: query, schema: {type: integer, minimum: 1, nullable: true}}
         - {name: sort_by, in: query, schema: {type: string, enum: [created_at, updated_at, price, year_built, bedrooms, bathrooms, area_sqft, address]}}
         - {name: sort_direction, in: query, schema: {type: string, enum: [asc, desc], default: desc}}
         - {name: amenities[], in: query, style: form, explode: true, schema: {type: array, maxItems: 20, items: {type: string, maxLength: 80}}}

--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -79,6 +79,7 @@ final class PropertyController
             ->yearBuiltRange($filters['min_year_built'] ?? null, $filters['max_year_built'] ?? null)
             ->propertyType($filters['property_type'] ?? null)
             ->category($filters['property_category_id'] ?? null)
+            ->when($filters['property_template_id'] ?? null, fn ($query) => $query->where('property_template_id', $filters['property_template_id']))
             ->country($filters['country'] ?? null)
             ->energyRating($filters['energy_rating'] ?? null)
             ->status($filters['status'] ?? null)

--- a/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
@@ -130,6 +130,9 @@ final class PropertyResource extends Resource
             ])
             ->filters([
                 SelectFilter::make('status')->options(collect(PropertyStatus::cases())->mapWithKeys(fn (PropertyStatus $status): array => [$status->value => str($status->value)->headline()->toString()])->all()),
+                SelectFilter::make('property_template_id')
+                    ->label('Template')
+                    ->options(fn (): array => PropertyTemplate::query()->forTeam(auth()->user()?->current_team_id ?? 0)->orderBy('name')->pluck('name', 'id')->all()),
                 Filter::make('minimum_scores')
                     ->form([
                         TextInput::make('energy_score')->numeric()->minValue(0)->maxValue(100),

--- a/tests/Architecture/RealEstateCapabilityCoverageTest.php
+++ b/tests/Architecture/RealEstateCapabilityCoverageTest.php
@@ -149,6 +149,18 @@ it('does not narrow advanced Livewire search when no template is selected', func
     expect($source)->toContain('->when($this->propertyTemplateId !== null, fn ($query) => $query->where(\'property_template_id\', $this->propertyTemplateId))');
 });
 
+it('keeps property template filters available across API and Filament', function (): void {
+    $api = file_get_contents(base_path('modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php'));
+    $openApi = file_get_contents(base_path('modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml'));
+    $filament = file_get_contents(base_path('modules/real-estate-properties-filament/src/Resources/PropertyResource.php'));
+
+    expect($api)->toContain("'property_template_id' => ['sometimes', 'nullable'")
+        ->toContain('where(\'property_template_id\', $filters[\'property_template_id\'])')
+        ->and($openApi)->toContain('name: property_template_id')
+        ->and($filament)->toContain("SelectFilter::make('property_template_id')")
+        ->toContain('PropertyTemplate::query()->forTeam');
+});
+
 it('keeps Filament resources tenant-scoped and lifecycle-delegated', function (): void {
     $root = dirname(__DIR__, 2);
 


### PR DESCRIPTION
## Summary
- add tenant-scoped property template filtering to API property listings
- document property_template_id in OpenAPI
- add tenant-scoped template filtering to the Filament property table
- cover the cross-surface filter contract

## Verification
- vendor/bin/pest
- 291 passed, 12 skipped, 1,489 assertions