### PR TITLE
Add progressive 3D property model reveal

### DIFF
--- a/modules/real-estate-properties-livewire/resources/views/property-detail.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/property-detail.blade.php
@@ -48,6 +48,24 @@
             @endif
         @endif
 
+        @if ($property->model3dUrl())
+            <section aria-label="3D property model">
+                <button type="button" wire:click="toggle3dModel">
+                    {{ $show3dModel ? 'Hide 3D model' : 'Show 3D model' }}
+                </button>
+                @if ($show3dModel)
+                    <model-viewer
+                        src="{{ $property->model3dUrl() }}"
+                        alt="3D model of {{ $property->title ?: $property->address }}"
+                        loading="lazy"
+                        camera-controls
+                        reveal="interaction"
+                        class="h-96 w-full"
+                    ></model-viewer>
+                @endif
+            </section>
+        @endif
+
         <button type="button" wire:click="toggleFavorite">{{ $isFavorited ? 'Unfavorite' : 'Favorite' }}</button>
         <button type="button" wire:click="requestViewing">Book a viewing</button>
     </article>

--- a/modules/real-estate-properties-livewire/src/Components/PropertyDetail.php
+++ b/modules/real-estate-properties-livewire/src/Components/PropertyDetail.php
@@ -19,6 +19,8 @@ final class PropertyDetail extends Component
 
     public bool $showVirtualTour = false;
 
+    public bool $show3dModel = false;
+
     public function mount(int|string $propertyId): void
     {
         $this->propertyId = $propertyId;
@@ -47,6 +49,11 @@ final class PropertyDetail extends Component
     public function toggleVirtualTour(): void
     {
         $this->showVirtualTour = ! $this->showVirtualTour;
+    }
+
+    public function toggle3dModel(): void
+    {
+        $this->show3dModel = ! $this->show3dModel;
     }
 
     public function render(): View

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -217,6 +217,16 @@ final class Property extends Model
         return $this->virtualTourEmbed();
     }
 
+    public function model3dUrl(): ?string
+    {
+        $url = (string) $this->model_3d_url;
+
+        return strtolower((string) parse_url($url, PHP_URL_SCHEME)) === 'https'
+            && filter_var($url, FILTER_VALIDATE_URL)
+            ? $url
+            : null;
+    }
+
     public function hasHolographicTour(): bool
     {
         return (bool) $this->holographic_enabled && filled($this->holographic_tour_url);

--- a/tests/Architecture/RealEstateCapabilityCoverageTest.php
+++ b/tests/Architecture/RealEstateCapabilityCoverageTest.php
@@ -178,6 +178,7 @@ it('keeps the property detail disclosure contract across adapters', function ():
     $filament = file_get_contents(base_path('modules/real-estate-properties-filament/src/Resources/PropertyResource.php'));
 
     expect($model)->toContain('public function daysListed(): ?int')
+        ->toContain('public function model3dUrl(): ?string')
         ->toContain('public function pricePerSquareFoot(): ?float')
         ->toContain('public function disclosureFacts(): array')
         ->and($definition)->toContain('Property detail disclosures')
@@ -188,8 +189,10 @@ it('keeps the property detail disclosure contract across adapters', function ():
         ->and($provider)->toContain("property-detail', Components\\PropertyDetail::class")
         ->and($detail)->toContain('forTeam($teamId)')
         ->toContain("property-viewing-requested")
+        ->toContain('toggle3dModel')
         ->and($view)->toContain('Property facts')
         ->toContain('Book a viewing')
+        ->toContain('loading="lazy"')
         ->and($filament)->toContain("label('Price / sq ft')")
         ->toContain("label('Days listed')")
         ->toContain("label('Floor plan')");

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -64,9 +64,30 @@ it('preserves legacy property listing attributes in the modular boundary', funct
         ->and($property->price)->toBe('425000.00')
         ->and($property->bedrooms)->toBe(3)
         ->and($property->virtual_tour_url)->toBe('https://example.test/tour')
+        ->and($property->model3dUrl())->toBe('https://example.test/model.glb')
         ->and($property->is_featured)->toBeTrue()
         ->and($property->energy_score)->toBe(82)
         ->and($property->reception_rooms)->toBe(2);
+});
+
+it('reveals a valid 3D property model only after an explicit Livewire action', function (): void {
+    $user = User::factory()->create(['current_team_id' => 10]);
+    $property = app(CreateProperty::class)->handle(10, $user->getKey(), [
+        'address' => '1 High Street',
+        'model_3d_url' => 'https://example.test/model.glb',
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire::component('test-property-detail-3d', PropertyDetail::class);
+
+    Livewire::test('test-property-detail-3d', ['propertyId' => $property->getKey()])
+        ->assertSee('Show 3D model')
+        ->assertDontSee('src="https://example.test/model.glb"')
+        ->call('toggle3dModel')
+        ->assertSet('show3dModel', true)
+        ->assertSee('src="https://example.test/model.glb"', escape: false)
+        ->assertSee('loading="lazy"', escape: false);
 });
 
 it('provides portable property detail disclosure facts', function (): void {


### PR DESCRIPTION
## Summary
- add a core HTTPS-only 3D model URL helper
- reveal the Livewire model viewer only after explicit interaction
- add architecture and feature coverage for safe lazy loading

## Verification
- 298 passed
- 12 skipped
- 1,536 assertions

This change is limited to core and Livewire modular surfaces; no React, Vue, Dart, Flutter, or Expo work is included.