### PR TITLE
Add tenant-scoped property comparison

### DIFF
--- a/modules/real-estate-properties-api/module.json
+++ b/modules/real-estate-properties-api/module.json
@@ -9,5 +9,5 @@
     "requires": {"php": "^8.5", "laravel": "^13.0", "packages": {"liberusoftware/real-estate-properties": "^1.0"}},
     "capabilities": ["real-estate.properties.api"],
     "default_enabled": true,
-    "features": ["Property list and detail transport", "Validated property creation"]
+    "features": ["Property list and detail transport", "Validated property creation", "Tenant-scoped property comparison"]
 }

--- a/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
+++ b/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
@@ -25,6 +25,14 @@ paths:
       security: [{sanctum: []}]
       responses:
         '201': {description: Property created}
+  /api/v1/real-estate/properties/compare:
+    get:
+      operationId: real.estate.properties.compare
+      security: [{sanctum: []}]
+      parameters:
+        - {name: property_ids[], in: query, required: true, style: form, explode: true, schema: {type: array, minItems: 2, maxItems: 4, uniqueItems: true, items: {type: integer, minimum: 1}}}
+      responses:
+        '200': {description: Authorized properties in requested comparison order}
   /api/v1/real-estate/properties/{id}:
     get:
       operationId: real.estate.properties.get

--- a/modules/real-estate-properties-api/routes/api.php
+++ b/modules/real-estate-properties-api/routes/api.php
@@ -8,6 +8,7 @@ use Liberu\RealEstate\PropertiesApi\Http\Controllers\PropertyTemplateController;
 Route::prefix('api/v1/real-estate/properties')->middleware(['api', 'auth:sanctum', 'throttle:api', 'api.idempotency'])->group(function (): void {
     Route::get('/', [PropertyController::class, 'index'])->name('real-estate.properties.index');
     Route::post('/', [PropertyController::class, 'store'])->name('real-estate.properties.store');
+    Route::get('/compare', [PropertyController::class, 'compare'])->name('real-estate.properties.compare');
     Route::post('/{property}/transition/{status}', [PropertyController::class, 'transition'])->name('real-estate.properties.transition');
     Route::post('/{property}/favorite', [PropertyController::class, 'favorite'])->name('real-estate.properties.favorite');
     Route::get('/{property}/similar', [PropertyController::class, 'similar'])->name('real-estate.properties.similar');

--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -186,6 +186,30 @@ final class PropertyController
         return PropertyResource::collection($property->similarProperties($limit))->response();
     }
 
+    public function compare(Request $request): JsonResponse
+    {
+        $teamId = $request->user()?->current_team_id;
+        abort_unless($teamId !== null, 403);
+
+        $validated = $request->validate([
+            'property_ids' => ['required', 'array', 'min:2', 'max:4'],
+            'property_ids.*' => ['integer', 'distinct'],
+        ]);
+
+        $properties = Property::query()
+            ->forTeam($teamId)
+            ->whereIn('id', $validated['property_ids'])
+            ->get()
+            ->keyBy(fn (Property $property): string => (string) $property->getKey());
+
+        abort_unless($properties->count() === count($validated['property_ids']), 404);
+
+        $ordered = collect($validated['property_ids'])
+            ->map(fn (int $id): Property => $properties->get((string) $id));
+
+        return PropertyResource::collection($ordered)->response();
+    }
+
     public function show(Request $request, Property $property): JsonResponse
     {
         abort_unless($request->user()?->current_team_id === $property->team_id, 404);

--- a/modules/real-estate-properties-livewire/resources/views/property-comparison.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/property-comparison.blade.php
@@ -1,0 +1,48 @@
+<div>
+    <section aria-label="Property comparison">
+        <h1>Compare properties</h1>
+
+        @if ($properties === [])
+            <p>Select two to four properties to compare.</p>
+        @else
+            <table>
+                <thead>
+                    <tr>
+                        <th scope="col">Feature</th>
+                        @foreach ($properties as $property)
+                            <th scope="col">
+                                {{ $property['title'] }}
+                                <button type="button" wire:click="removeProperty('{{ $property['id'] }}')">Remove</button>
+                            </th>
+                        @endforeach
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($comparisonFields as $field)
+                        <tr wire:key="comparison-{{ $field }}">
+                            <th scope="row">{{ str_replace('_', ' ', ucfirst($field)) }}</th>
+                            @foreach ($properties as $property)
+                                <td>{{ $property[$field] ?? 'Not supplied' }}</td>
+                            @endforeach
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        @endif
+
+        @if (count($propertyIds) < 4)
+            <label for="comparison-search">Add a property</label>
+            <input id="comparison-search" type="search" wire:model.live="searchTerm" minlength="3" autocomplete="off">
+            @if ($searchResults !== [])
+                <ul aria-label="Property search results">
+                    @foreach ($searchResults as $result)
+                        <li wire:key="comparison-result-{{ $result['id'] }}">
+                            {{ $result['title'] }}
+                            <button type="button" wire:click="addProperty('{{ $result['id'] }}')">Add</button>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        @endif
+    </section>
+</div>

--- a/modules/real-estate-properties-livewire/src/Components/PropertyComparison.php
+++ b/modules/real-estate-properties-livewire/src/Components/PropertyComparison.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertiesLivewire\Components;
+
+use Illuminate\Contracts\View\View;
+use Liberu\RealEstate\Properties\Models\Property;
+use Livewire\Component;
+
+final class PropertyComparison extends Component
+{
+    /** @var list<int|string> */
+    public array $propertyIds = [];
+
+    /** @var list<array<string, mixed>> */
+    public array $properties = [];
+
+    /** @var list<array<string, mixed>> */
+    public array $searchResults = [];
+
+    public string $searchTerm = '';
+
+    /** @var list<string> */
+    public array $comparisonFields = [
+        'price', 'address', 'bedrooms', 'bathrooms', 'area_sqft',
+        'year_built', 'property_type', 'status',
+    ];
+
+    public function mount(string|array|null $propertyIds = null): void
+    {
+        $this->propertyIds = $this->normalizeIds($propertyIds);
+        $this->loadProperties();
+    }
+
+    public function updatedSearchTerm(): void
+    {
+        $this->searchProperties();
+    }
+
+    public function addProperty(int|string $propertyId): void
+    {
+        $propertyId = (string) $propertyId;
+
+        if (count($this->propertyIds) >= 4 || in_array($propertyId, array_map('strval', $this->propertyIds), true)) {
+            return;
+        }
+
+        $this->propertyForTeam($propertyId);
+        $this->propertyIds[] = $propertyId;
+        $this->loadProperties();
+        $this->searchProperties();
+    }
+
+    public function removeProperty(int|string $propertyId): void
+    {
+        $propertyId = (string) $propertyId;
+        $this->propertyIds = array_values(array_filter(
+            $this->propertyIds,
+            static fn (int|string $id): bool => (string) $id !== $propertyId,
+        ));
+        $this->loadProperties();
+        $this->searchProperties();
+    }
+
+    public function searchProperties(): void
+    {
+        $term = trim($this->searchTerm);
+        if (mb_strlen($term) < 3) {
+            $this->searchResults = [];
+
+            return;
+        }
+
+        $excluded = array_map('strval', $this->propertyIds);
+        $this->searchResults = Property::query()
+            ->forTeam($this->teamId())
+            ->search($term)
+            ->when($excluded !== [], fn ($query) => $query->whereNotIn('id', $excluded))
+            ->limit(5)
+            ->get()
+            ->map(fn (Property $property): array => $property->comparisonData())
+            ->all();
+    }
+
+    public function render(): View
+    {
+        return view('real-estate-properties-livewire::property-comparison');
+    }
+
+    /** @return list<int|string> */
+    private function normalizeIds(string|array|null $propertyIds): array
+    {
+        $ids = is_string($propertyIds) ? explode(',', $propertyIds) : ($propertyIds ?? []);
+
+        return array_values(array_unique(array_filter(
+            array_map(static fn (mixed $id): string => trim((string) $id), $ids),
+            static fn (string $id): bool => $id !== '',
+        )));
+    }
+
+    private function loadProperties(): void
+    {
+        $this->properties = Property::query()
+            ->forTeam($this->teamId())
+            ->whereIn('id', $this->propertyIds)
+            ->get()
+            ->sortBy(fn (Property $property): int => array_search((string) $property->getKey(), array_map('strval', $this->propertyIds), true))
+            ->values()
+            ->map(fn (Property $property): array => $property->comparisonData())
+            ->all();
+    }
+
+    private function propertyForTeam(string $propertyId): Property
+    {
+        return Property::query()->forTeam($this->teamId())->findOrFail($propertyId);
+    }
+
+    private function teamId(): int|string
+    {
+        $teamId = auth()->user()?->current_team_id;
+        abort_unless($teamId !== null, 403);
+
+        return $teamId;
+    }
+}

--- a/modules/real-estate-properties-livewire/src/PropertiesLivewireServiceProvider.php
+++ b/modules/real-estate-properties-livewire/src/PropertiesLivewireServiceProvider.php
@@ -15,6 +15,7 @@ final class PropertiesLivewireServiceProvider extends ServiceProvider
         Livewire::component('module-real-estate-properties::property-list', Components\PropertyList::class);
         Livewire::component('module-real-estate-properties::advanced-property-search', Components\AdvancedPropertySearch::class);
         Livewire::component('module-real-estate-properties::property-detail', Components\PropertyDetail::class);
+        Livewire::component('module-real-estate-properties::property-comparison', Components\PropertyComparison::class);
         Livewire::component('real-estate-properties-list', Components\PropertyList::class);
     }
 }

--- a/modules/real-estate-properties/module.json
+++ b/modules/real-estate-properties/module.json
@@ -23,6 +23,6 @@
     "capabilities": ["real-estate.properties"],
     "default_enabled": true,
     "features": [
-        "Address/location", "Categories", "Templates", "Favorites", "Units", "Characteristics", "Tenure", "Utilities", "Features", "Status", "History", "Keys", "Property detail disclosures"
+        "Address/location", "Categories", "Templates", "Favorites", "Units", "Characteristics", "Tenure", "Utilities", "Features", "Status", "History", "Keys", "Property detail disclosures", "Property comparisons"
     ]
 }

--- a/modules/real-estate-properties/src/Domain/PropertiesCapabilityDefinition.php
+++ b/modules/real-estate-properties/src/Domain/PropertiesCapabilityDefinition.php
@@ -9,7 +9,7 @@ final class PropertiesCapabilityDefinition
     /** @return array<string, array{label: string, required: list<string>, behaviors: list<string>}> */
     public static function all(): array
     {
-        $labels = ['Address/location', 'Categories', 'Templates', 'Favorites', 'Units', 'Characteristics', 'Tenure', 'Utilities', 'Features', 'Status', 'History', 'Keys', 'Property detail disclosures'];
+        $labels = ['Address/location', 'Categories', 'Templates', 'Favorites', 'Units', 'Characteristics', 'Tenure', 'Utilities', 'Features', 'Status', 'History', 'Keys', 'Property detail disclosures', 'Property comparisons'];
         $result = [];
         foreach ($labels as $label) {
             $key = strtolower(str_replace([' ', '/', '-'], ['_', '_', '_'], $label));

--- a/modules/real-estate-properties/src/Models/Property.php
+++ b/modules/real-estate-properties/src/Models/Property.php
@@ -262,6 +262,24 @@ final class Property extends Model
         return round((float) $this->price / (float) $this->area_sqft, 2);
     }
 
+    /** @return array<string, mixed> */
+    public function comparisonData(): array
+    {
+        return [
+            'id' => $this->getKey(),
+            'title' => $this->title ?: $this->address,
+            'address' => $this->address,
+            'price' => $this->price,
+            'currency' => $this->currency,
+            'bedrooms' => $this->bedrooms,
+            'bathrooms' => $this->bathrooms,
+            'area_sqft' => $this->area_sqft,
+            'year_built' => $this->year_built,
+            'property_type' => $this->property_type,
+            'status' => $this->status?->value,
+        ];
+    }
+
     /** @return array<string, array{label: string, value: int|float|string|null, source: string}> */
     public function disclosureFacts(): array
     {

--- a/tests/Architecture/RealEstateCapabilityCoverageTest.php
+++ b/tests/Architecture/RealEstateCapabilityCoverageTest.php
@@ -217,6 +217,23 @@ it('keeps the property gallery contract connected to the media boundary', functi
         ->and($mediaCreate)->toContain("'siteplan'");
 });
 
+it('keeps the property comparison contract tenant-scoped across core, API, and Livewire', function (): void {
+    $model = file_get_contents(base_path('modules/real-estate-properties/src/Models/Property.php'));
+    $api = file_get_contents(base_path('modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php'));
+    $routes = file_get_contents(base_path('modules/real-estate-properties-api/routes/api.php'));
+    $component = file_get_contents(base_path('modules/real-estate-properties-livewire/src/Components/PropertyComparison.php'));
+    $provider = file_get_contents(base_path('modules/real-estate-properties-livewire/src/PropertiesLivewireServiceProvider.php'));
+
+    expect($model)->toContain('public function comparisonData(): array')
+        ->and($api)->toContain('public function compare(Request $request): JsonResponse')
+        ->toContain("forTeam(\$teamId)")
+        ->and($routes)->toContain("'/compare'")
+        ->and($component)->toContain('count($this->propertyIds) >= 4')
+        ->toContain('whereNotIn')
+        ->toContain('teamId()')
+        ->and($provider)->toContain("property-comparison', Components\\PropertyComparison::class");
+});
+
 it('keeps Filament resources tenant-scoped and lifecycle-delegated', function (): void {
     $root = dirname(__DIR__, 2);
 

--- a/tests/Feature/RealEstatePropertyComparisonTest.php
+++ b/tests/Feature/RealEstatePropertyComparisonTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
+use Liberu\RealEstate\Properties\Application\CreateProperty;
+use Liberu\RealEstate\PropertiesLivewire\Components\PropertyComparison;
+use Livewire\Livewire;
+
+it('compares only team properties in the requested order through the API', function (): void {
+    $user = User::factory()->create(['current_team_id' => 10]);
+    $first = app(CreateProperty::class)->handle(10, $user->getKey(), ['address' => 'First Street', 'title' => 'First home']);
+    $second = app(CreateProperty::class)->handle(10, $user->getKey(), ['address' => 'Second Street', 'title' => 'Second home']);
+    $otherTeam = app(CreateProperty::class)->handle(11, $user->getKey(), ['address' => 'Private Street', 'title' => 'Private home']);
+
+    RateLimiter::for('api', static fn (): Limit => Limit::perMinute(1000));
+    $this->actingAs($user, 'sanctum')
+        ->getJson('/api/v1/real-estate/properties/compare?property_ids[]='.$second->getKey().'&property_ids[]='.$first->getKey())
+        ->assertOk()
+        ->assertJsonPath('data.0.id', $second->getKey())
+        ->assertJsonPath('data.1.id', $first->getKey());
+
+    $this->actingAs($user, 'sanctum')
+        ->getJson('/api/v1/real-estate/properties/compare?property_ids[]='.$first->getKey().'&property_ids[]='.$otherTeam->getKey())
+        ->assertNotFound();
+});
+
+it('searches and manages a bounded tenant-scoped Livewire comparison', function (): void {
+    $user = User::factory()->create(['current_team_id' => 10]);
+    $first = app(CreateProperty::class)->handle(10, $user->getKey(), ['address' => 'First Street', 'title' => 'First home']);
+    $second = app(CreateProperty::class)->handle(10, $user->getKey(), ['address' => 'Second Street', 'title' => 'Second home']);
+    $third = app(CreateProperty::class)->handle(10, $user->getKey(), ['address' => 'Third Street', 'title' => 'Third home']);
+    app(CreateProperty::class)->handle(11, $user->getKey(), ['address' => 'First Private Street', 'title' => 'Private home']);
+
+    $this->actingAs($user);
+    Livewire::component('test-property-comparison', PropertyComparison::class);
+
+    Livewire::test('test-property-comparison', ['propertyIds' => [$first->getKey(), $second->getKey()]])
+        ->assertSee('First home')
+        ->assertSee('Second home')
+        ->set('searchTerm', 'Third')
+        ->assertSee('Third home')
+        ->assertDontSee('Private home')
+        ->call('addProperty', $third->getKey())
+        ->assertCount('propertyIds', 3)
+        ->call('removeProperty', $second->getKey())
+        ->assertCount('propertyIds', 2);
+});


### PR DESCRIPTION
## Summary
- add a reusable comparison projection to the property core
- add a validated API comparison endpoint for two to four properties
- add a tenant-scoped Livewire comparison component with bounded search and ordering
- document the capability in manifests/OpenAPI and add coverage

## Verification
- 303 passed
- 12 skipped
- 1,561 assertions

No React, Vue, Dart, Flutter, or Expo work is included.