### PR TITLE
Add modular property tax estimates

### DIFF
--- a/modules/real-estate-properties-api/module.json
+++ b/modules/real-estate-properties-api/module.json
@@ -9,5 +9,5 @@
     "requires": {"php": "^8.5", "laravel": "^13.0", "packages": {"liberusoftware/real-estate-properties": "^1.0"}},
     "capabilities": ["real-estate.properties.api"],
     "default_enabled": true,
-    "features": ["Property list and detail transport", "Validated property creation", "Tenant-scoped property comparison"]
+    "features": ["Property list and detail transport", "Validated property creation", "Tenant-scoped property comparison", "Property tax estimates"]
 }

--- a/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
+++ b/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
@@ -33,6 +33,23 @@ paths:
         - {name: property_ids[], in: query, required: true, style: form, explode: true, schema: {type: array, minItems: 2, maxItems: 4, uniqueItems: true, items: {type: integer, minimum: 1}}}
       responses:
         '200': {description: Authorized properties in requested comparison order}
+  /api/v1/real-estate/properties/tax-estimate:
+    post:
+      operationId: real.estate.properties.taxEstimate
+      security: [{sanctum: []}]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [purchase_price]
+              properties:
+                purchase_price: {type: number, minimum: 0}
+                country: {type: string, default: UK}
+                buyer_type: {type: string, enum: [first_time_buyer, home_mover, additional_property]}
+      responses:
+        '200': {description: Estimated transaction costs; all figures are estimates}
   /api/v1/real-estate/properties/{id}:
     get:
       operationId: real.estate.properties.get

--- a/modules/real-estate-properties-api/routes/api.php
+++ b/modules/real-estate-properties-api/routes/api.php
@@ -9,6 +9,7 @@ Route::prefix('api/v1/real-estate/properties')->middleware(['api', 'auth:sanctum
     Route::get('/', [PropertyController::class, 'index'])->name('real-estate.properties.index');
     Route::post('/', [PropertyController::class, 'store'])->name('real-estate.properties.store');
     Route::get('/compare', [PropertyController::class, 'compare'])->name('real-estate.properties.compare');
+    Route::post('/tax-estimate', [PropertyController::class, 'taxEstimate'])->name('real-estate.properties.tax-estimate');
     Route::post('/{property}/transition/{status}', [PropertyController::class, 'transition'])->name('real-estate.properties.transition');
     Route::post('/{property}/favorite', [PropertyController::class, 'favorite'])->name('real-estate.properties.favorite');
     Route::get('/{property}/similar', [PropertyController::class, 'similar'])->name('real-estate.properties.similar');

--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use Illuminate\Validation\Rule;
 use Liberu\RealEstate\Properties\Application\CreateProperty;
 use Liberu\RealEstate\Properties\Application\DeleteProperty;
+use Liberu\RealEstate\Properties\Application\EstimatePropertyTax;
 use Liberu\RealEstate\Properties\Application\RecordPropertyKey;
 use Liberu\RealEstate\Properties\Application\TransitionProperty;
 use Liberu\RealEstate\Properties\Application\TogglePropertyFavorite;
@@ -208,6 +209,25 @@ final class PropertyController
             ->map(fn (int $id): Property => $properties->get((string) $id));
 
         return PropertyResource::collection($ordered)->response();
+    }
+
+    public function taxEstimate(Request $request, EstimatePropertyTax $estimate): JsonResponse
+    {
+        $validated = $request->validate([
+            'purchase_price' => ['required', 'numeric', 'min:0'],
+            'country' => ['sometimes', 'string', 'max:80'],
+            'buyer_type' => ['sometimes', Rule::in(EstimatePropertyTax::BUYER_TYPES)],
+            'annual_tax_rate' => ['sometimes', 'numeric', 'min:0', 'max:1'],
+            'transfer_tax_rate' => ['sometimes', 'numeric', 'min:0', 'max:1'],
+            'tax_rate' => ['sometimes', 'numeric', 'min:0', 'max:1'],
+            'country_name' => ['sometimes', 'string', 'max:80'],
+        ]);
+
+        return response()->json($estimate->handle(
+            (float) $validated['purchase_price'],
+            (string) ($validated['country'] ?? 'UK'),
+            $validated,
+        ));
     }
 
     public function show(Request $request, Property $property): JsonResponse

--- a/modules/real-estate-properties-filament/module.json
+++ b/modules/real-estate-properties-filament/module.json
@@ -10,5 +10,5 @@
     "presentation": {"filament": {"admin": ["Liberu\\RealEstate\\PropertiesFilament\\PropertiesFilamentPlugin"]}},
     "capabilities": ["real-estate.properties.filament"],
     "default_enabled": true,
-    "features": ["Property resource", "Property category resource", "Property template resource", "Team-scoped property administration"]
+    "features": ["Property resource", "Property category resource", "Property template resource", "Team-scoped property administration", "Property tax estimates"]
 }

--- a/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
@@ -25,6 +25,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Liberu\RealEstate\Core\Models\Branch;
 use Liberu\RealEstate\Properties\Application\RecordPropertyKey;
+use Liberu\RealEstate\Properties\Application\EstimatePropertyTax;
 use Liberu\RealEstate\Properties\Application\TransitionProperty;
 use Liberu\RealEstate\Properties\Application\UpsertPropertyUnit;
 use Liberu\RealEstate\Properties\Domain\PropertyStatus;
@@ -162,6 +163,24 @@ final class PropertyResource extends Resource
                             ->success()
                             ->send();
                     }),
+                Action::make('tax_estimate')
+                    ->label('Estimate tax')
+                    ->form([
+                        Select::make('buyer_type')->options([
+                            'first_time_buyer' => 'First-time buyer',
+                            'home_mover' => 'Home mover',
+                            'additional_property' => 'Additional property',
+                        ])->required()->default('home_mover'),
+                        TextInput::make('country')->required()->maxLength(80)->default('GB'),
+                    ])
+                    ->action(function (Property $record, array $data): void {
+                        $estimate = app(EstimatePropertyTax::class)->handle((float) $record->price, (string) $data['country'], $data);
+                        Notification::make()
+                            ->title('Estimated tax: '.number_format((float) $estimate['total_tax'], 2))
+                            ->warning()
+                            ->send();
+                    })
+                    ->visible(fn (Property $record): bool => $record->price !== null),
                 Action::make('unit')->form([TextInput::make('label')->required()->maxLength(80), TextInput::make('bedrooms')->numeric()->minValue(0), TextInput::make('bathrooms')->numeric()->minValue(0), TextInput::make('area_sqft')->numeric()->minValue(0)])->action(fn (Property $record, array $data): mixed => app(UpsertPropertyUnit::class)->handle($record, (int) auth()->user()->current_team_id, $data)),
                 Action::make('key')->form([TextInput::make('key_reference')->required()->maxLength(80), TextInput::make('quantity')->numeric()->required()->minValue(1), Textarea::make('notes')])->action(fn (Property $record, array $data): mixed => app(RecordPropertyKey::class)->handle($record, (int) auth()->user()->current_team_id, $data)),
                 Action::make('available')

--- a/modules/real-estate-properties-livewire/module.json
+++ b/modules/real-estate-properties-livewire/module.json
@@ -9,5 +9,5 @@
     "requires": {"php": "^8.5", "laravel": "^13.0", "packages": {"liberusoftware/real-estate-properties": "^1.0", "liberusoftware/real-estate-media-and-documents": "^1.0"}},
     "capabilities": ["real-estate.properties.livewire"],
     "default_enabled": true,
-    "features": ["Property search state", "Category filtering", "Template filtering", "Advanced bounded filters", "Validation and empty states", "Property detail disclosures", "Property gallery", "Property comparison"]
+    "features": ["Property search state", "Category filtering", "Template filtering", "Advanced bounded filters", "Validation and empty states", "Property detail disclosures", "Property gallery", "Property comparison", "Property tax estimates"]
 }

--- a/modules/real-estate-properties-livewire/resources/views/property-tax-estimator.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/property-tax-estimator.blade.php
@@ -1,0 +1,30 @@
+<div>
+    <section aria-label="Property tax estimator">
+        <h2>Property tax estimate</h2>
+        <p>This calculator provides an estimate only; confirm current rates with a qualified adviser.</p>
+
+        <label for="tax-buyer-type">Buyer type</label>
+        <select id="tax-buyer-type" wire:model="buyerType">
+            <option value="first_time_buyer">First-time buyer</option>
+            <option value="home_mover">Home mover</option>
+            <option value="additional_property">Additional property</option>
+        </select>
+
+        <label for="tax-country">Country</label>
+        <input id="tax-country" type="text" wire:model="country" maxlength="80">
+
+        <button type="button" wire:click="calculateTax">Calculate estimate</button>
+
+        @if ($estimate)
+            <dl>
+                <dt>Estimated tax</dt>
+                <dd>{{ number_format((float) ($estimate['total_tax'] ?? 0), 2) }}</dd>
+                <dt>Additional costs</dt>
+                <dd>{{ number_format((float) ($estimate['total_additional_costs'] ?? 0), 2) }}</dd>
+                <dt>Total estimated cost</dt>
+                <dd>{{ number_format((float) ($estimate['total_cost'] ?? $property->price), 2) }}</dd>
+            </dl>
+            <button type="button" wire:click="resetCalculation">Reset</button>
+        @endif
+    </section>
+</div>

--- a/modules/real-estate-properties-livewire/src/Components/PropertyTaxEstimator.php
+++ b/modules/real-estate-properties-livewire/src/Components/PropertyTaxEstimator.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertiesLivewire\Components;
+
+use Illuminate\Contracts\View\View;
+use Liberu\RealEstate\Properties\Application\EstimatePropertyTax;
+use Liberu\RealEstate\Properties\Models\Property;
+use Livewire\Component;
+
+final class PropertyTaxEstimator extends Component
+{
+    public int|string $propertyId;
+
+    public string $buyerType = 'home_mover';
+
+    public string $country = 'GB';
+
+    /** @var array<string, mixed>|null */
+    public ?array $estimate = null;
+
+    public function mount(int|string $propertyId): void
+    {
+        $this->propertyId = $propertyId;
+        $this->country = (string) (Property::query()->forTeam($this->teamId())->findOrFail($propertyId)->country ?: 'GB');
+    }
+
+    public function calculateTax(EstimatePropertyTax $estimate): void
+    {
+        $property = $this->property();
+
+        $this->estimate = $estimate->handle((float) $property->price, $this->country, [
+            'buyer_type' => $this->buyerType,
+        ]);
+    }
+
+    public function resetCalculation(): void
+    {
+        $this->estimate = null;
+        $this->buyerType = 'home_mover';
+    }
+
+    public function render(): View
+    {
+        return view('real-estate-properties-livewire::property-tax-estimator', ['property' => $this->property()]);
+    }
+
+    private function property(): Property
+    {
+        return Property::query()->forTeam($this->teamId())->findOrFail($this->propertyId);
+    }
+
+    private function teamId(): int|string
+    {
+        $teamId = auth()->user()?->current_team_id;
+        abort_unless($teamId !== null, 403);
+
+        return $teamId;
+    }
+}

--- a/modules/real-estate-properties-livewire/src/PropertiesLivewireServiceProvider.php
+++ b/modules/real-estate-properties-livewire/src/PropertiesLivewireServiceProvider.php
@@ -16,6 +16,7 @@ final class PropertiesLivewireServiceProvider extends ServiceProvider
         Livewire::component('module-real-estate-properties::advanced-property-search', Components\AdvancedPropertySearch::class);
         Livewire::component('module-real-estate-properties::property-detail', Components\PropertyDetail::class);
         Livewire::component('module-real-estate-properties::property-comparison', Components\PropertyComparison::class);
+        Livewire::component('module-real-estate-properties::property-tax-estimator', Components\PropertyTaxEstimator::class);
         Livewire::component('real-estate-properties-list', Components\PropertyList::class);
     }
 }

--- a/modules/real-estate-properties/module.json
+++ b/modules/real-estate-properties/module.json
@@ -23,6 +23,6 @@
     "capabilities": ["real-estate.properties"],
     "default_enabled": true,
     "features": [
-        "Address/location", "Categories", "Templates", "Favorites", "Units", "Characteristics", "Tenure", "Utilities", "Features", "Status", "History", "Keys", "Property detail disclosures", "Property comparisons"
+        "Address/location", "Categories", "Templates", "Favorites", "Units", "Characteristics", "Tenure", "Utilities", "Features", "Status", "History", "Keys", "Property detail disclosures", "Property comparisons", "Property tax estimates"
     ]
 }

--- a/modules/real-estate-properties/src/Application/EstimatePropertyTax.php
+++ b/modules/real-estate-properties/src/Application/EstimatePropertyTax.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\Properties\Application;
+
+use InvalidArgumentException;
+
+final class EstimatePropertyTax
+{
+    public const BUYER_TYPES = ['first_time_buyer', 'home_mover', 'additional_property'];
+
+    /** @param array<string, mixed> $options */
+    /** @return array<string, mixed> */
+    public function handle(float $purchasePrice, string $country = 'UK', array $options = []): array
+    {
+        if ($purchasePrice < 0) {
+            throw new InvalidArgumentException('Purchase price cannot be negative.');
+        }
+
+        return match (strtoupper($country)) {
+            'UK', 'GB', 'UNITED KINGDOM' => $this->uk($purchasePrice, $options),
+            'US', 'USA', 'UNITED STATES' => $this->us($purchasePrice, $options),
+            default => $this->generic($purchasePrice, $options),
+        };
+    }
+
+    /** @param array<string, mixed> $options */
+    private function uk(float $price, array $options): array
+    {
+        $buyerType = $this->buyerType($options['buyer_type'] ?? 'home_mover');
+        $stampDuty = $this->bandedTax($price, $this->ukRates($buyerType));
+        $legalFees = $this->tieredFee($price, [100000 => 850, 250000 => 1200, 500000 => 1500, 1000000 => 2000], 2500);
+        $surveyFees = $this->tieredFee($price, [100000 => 400, 250000 => 600, 500000 => 900, 1000000 => 1200], 1500);
+        $landRegistryFees = $this->tieredFee($price, [80000 => 40, 100000 => 80, 200000 => 190, 500000 => 270, 1000000 => 540], 910, true);
+        $additional = $legalFees + $surveyFees + $landRegistryFees;
+
+        return $this->result('United Kingdom', $price, $stampDuty, $additional, [
+            'buyer_type' => $buyerType,
+            'stamp_duty' => round($stampDuty, 2),
+            'effective_tax_rate' => $this->rate($stampDuty, $price),
+            'additional_costs' => ['legal_fees' => $legalFees, 'survey_fees' => $surveyFees, 'land_registry_fees' => $landRegistryFees],
+        ]);
+    }
+
+    /** @param array<string, mixed> $options */
+    private function us(float $price, array $options): array
+    {
+        $transferTax = $price * (float) ($options['transfer_tax_rate'] ?? 0.01);
+        $annualTax = $price * (float) ($options['annual_tax_rate'] ?? 0.011);
+        $recordingFees = 500.0;
+        $titleInsurance = $price * 0.005;
+
+        return $this->result('United States', $price, $transferTax, $recordingFees + $titleInsurance, [
+            'transfer_tax' => round($transferTax, 2),
+            'annual_property_tax' => round($annualTax, 2),
+            'effective_tax_rate' => $this->rate($transferTax, $price),
+            'additional_costs' => ['recording_fees' => $recordingFees, 'title_insurance' => round($titleInsurance, 2)],
+        ]);
+    }
+
+    /** @param array<string, mixed> $options */
+    private function generic(float $price, array $options): array
+    {
+        $tax = $price * (float) ($options['tax_rate'] ?? 0.03);
+        $legalFees = $price * 0.01;
+
+        return $this->result((string) ($options['country_name'] ?? 'Other'), $price, $tax, $legalFees + 1000, [
+            'property_transfer_tax' => round($tax, 2),
+            'effective_tax_rate' => $this->rate($tax, $price),
+            'additional_costs' => ['legal_fees' => round($legalFees, 2), 'registration_fees' => 1000.0],
+        ]);
+    }
+
+    /** @param array<string, mixed> $details */
+    /** @return array<string, mixed> */
+    private function result(string $country, float $price, float $tax, float $additional, array $details): array
+    {
+        $tax = round($tax, 2);
+        $additional = round($additional, 2);
+
+        return array_merge([
+            'estimated' => true,
+            'country' => $country,
+            'purchase_price' => round($price, 2),
+            'total_tax' => $tax,
+            'total_additional_costs' => $additional,
+            'total_cost' => round($price + $tax + $additional, 2),
+        ], $details);
+    }
+
+    /** @param array<int|float, float> $rates */
+    private function bandedTax(float $price, array $rates): float
+    {
+        $tax = 0.0;
+        $previous = 0.0;
+        foreach ($rates as $threshold => $rate) {
+            if ($price > $threshold) {
+                $tax += ((float) $threshold - $previous) * $rate;
+                $previous = (float) $threshold;
+                continue;
+            }
+            $tax += ($price - $previous) * $rate;
+            break;
+        }
+
+        return $tax;
+    }
+
+    /** @param array<int, float|int> $fees */
+    private function tieredFee(float $price, array $fees, float|int $last, bool $inclusive = false): float
+    {
+        foreach ($fees as $threshold => $fee) {
+            if ($inclusive ? $price <= $threshold : $price < $threshold) {
+                return (float) $fee;
+            }
+        }
+
+        return (float) $last;
+    }
+
+    /** @return array<int|float, float> */
+    private function ukRates(string $buyerType): array
+    {
+        return match ($buyerType) {
+            'first_time_buyer' => [0 => 0, 300000 => 0, 500000 => 0.05, 925000 => 0.05, 1500000 => 0.10, PHP_INT_MAX => 0.12],
+            'additional_property' => [0 => 0.03, 250000 => 0.03, 925000 => 0.08, 1500000 => 0.13, PHP_INT_MAX => 0.15],
+            default => [0 => 0, 250000 => 0, 925000 => 0.05, 1500000 => 0.10, PHP_INT_MAX => 0.12],
+        };
+    }
+
+    private function buyerType(mixed $buyerType): string
+    {
+        return in_array($buyerType, self::BUYER_TYPES, true) ? $buyerType : 'home_mover';
+    }
+
+    private function rate(float $tax, float $price): float
+    {
+        return $price > 0 ? round($tax / $price * 100, 2) : 0.0;
+    }
+}

--- a/modules/real-estate-properties/src/Domain/PropertiesCapabilityDefinition.php
+++ b/modules/real-estate-properties/src/Domain/PropertiesCapabilityDefinition.php
@@ -9,7 +9,7 @@ final class PropertiesCapabilityDefinition
     /** @return array<string, array{label: string, required: list<string>, behaviors: list<string>}> */
     public static function all(): array
     {
-        $labels = ['Address/location', 'Categories', 'Templates', 'Favorites', 'Units', 'Characteristics', 'Tenure', 'Utilities', 'Features', 'Status', 'History', 'Keys', 'Property detail disclosures', 'Property comparisons'];
+        $labels = ['Address/location', 'Categories', 'Templates', 'Favorites', 'Units', 'Characteristics', 'Tenure', 'Utilities', 'Features', 'Status', 'History', 'Keys', 'Property detail disclosures', 'Property comparisons', 'Property tax estimates'];
         $result = [];
         foreach ($labels as $label) {
             $key = strtolower(str_replace([' ', '/', '-'], ['_', '_', '_'], $label));

--- a/tests/Architecture/RealEstateCapabilityCoverageTest.php
+++ b/tests/Architecture/RealEstateCapabilityCoverageTest.php
@@ -234,6 +234,35 @@ it('keeps the property comparison contract tenant-scoped across core, API, and L
         ->and($provider)->toContain("property-comparison', Components\\PropertyComparison::class");
 });
 
+it('keeps property tax estimates available across the modular adapters', function (): void {
+    $core = file_get_contents(base_path('modules/real-estate-properties/src/Application/EstimatePropertyTax.php'));
+    $definition = file_get_contents(base_path('modules/real-estate-properties/src/Domain/PropertiesCapabilityDefinition.php'));
+    $api = file_get_contents(base_path('modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php'));
+    $routes = file_get_contents(base_path('modules/real-estate-properties-api/routes/api.php'));
+    $openApi = file_get_contents(base_path('modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml'));
+    $component = file_get_contents(base_path('modules/real-estate-properties-livewire/src/Components/PropertyTaxEstimator.php'));
+    $view = file_get_contents(base_path('modules/real-estate-properties-livewire/resources/views/property-tax-estimator.blade.php'));
+    $provider = file_get_contents(base_path('modules/real-estate-properties-livewire/src/PropertiesLivewireServiceProvider.php'));
+    $filament = file_get_contents(base_path('modules/real-estate-properties-filament/src/Resources/PropertyResource.php'));
+
+    expect($core)->toContain('public const BUYER_TYPES')
+        ->toContain("'estimated' => true")
+        ->toContain('United Kingdom')
+        ->and($definition)->toContain('Property tax estimates')
+        ->and($api)->toContain('public function taxEstimate(Request $request, EstimatePropertyTax $estimate)')
+        ->toContain('purchase_price')
+        ->and($routes)->toContain("'/tax-estimate'")
+        ->and($openApi)->toContain('/api/v1/real-estate/properties/tax-estimate')
+        ->toContain('real.estate.properties.taxEstimate')
+        ->and($component)->toContain('forTeam($this->teamId())')
+        ->toContain('calculateTax')
+        ->and($view)->toContain('qualified adviser')
+        ->toContain('wire:click="calculateTax"')
+        ->and($provider)->toContain("property-tax-estimator', Components\\PropertyTaxEstimator::class")
+        ->and($filament)->toContain("Action::make('tax_estimate')")
+        ->toContain('EstimatePropertyTax');
+});
+
 it('keeps Filament resources tenant-scoped and lifecycle-delegated', function (): void {
     $root = dirname(__DIR__, 2);
 

--- a/tests/Feature/RealEstatePropertyTaxTest.php
+++ b/tests/Feature/RealEstatePropertyTaxTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
+use InvalidArgumentException;
+use Liberu\RealEstate\Properties\Application\EstimatePropertyTax;
+use Liberu\RealEstate\Properties\Application\CreateProperty;
+use Liberu\RealEstate\PropertiesLivewire\Components\PropertyTaxEstimator;
+use Livewire\Livewire;
+
+it('returns an explicitly marked UK tax estimate with legacy cost bands', function (): void {
+    $estimate = app(EstimatePropertyTax::class)->handle(300000, 'GB', ['buyer_type' => 'home_mover']);
+
+    expect($estimate['estimated'])->toBeTrue()
+        ->and($estimate['country'])->toBe('United Kingdom')
+        ->and($estimate['total_tax'])->toBe(2500.0)
+        ->and($estimate['total_additional_costs'])->toBe(2670.0)
+        ->and($estimate['total_cost'])->toBe(305170.0);
+});
+
+it('rejects negative purchase prices and falls back to a safe UK buyer type', function (): void {
+    expect(fn () => app(EstimatePropertyTax::class)->handle(-1))->toThrow(InvalidArgumentException::class);
+
+    $estimate = app(EstimatePropertyTax::class)->handle(100000, 'UK', ['buyer_type' => 'unknown']);
+
+    expect($estimate['buyer_type'])->toBe('home_mover');
+});
+
+it('serves estimates through the authenticated API boundary', function (): void {
+    $user = User::factory()->create(['current_team_id' => 10]);
+    RateLimiter::for('api', static fn (): Limit => Limit::perMinute(1000));
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/real-estate/properties/tax-estimate', [
+            'purchase_price' => 300000,
+            'country' => 'GB',
+            'buyer_type' => 'home_mover',
+        ])
+        ->assertOk()
+        ->assertJsonPath('estimated', true)
+        ->assertJsonPath('total_tax', 2500);
+});
+
+it('calculates a tenant-scoped estimate through Livewire', function (): void {
+    $user = User::factory()->create(['current_team_id' => 10]);
+    $property = app(CreateProperty::class)->handle(10, $user->getKey(), [
+        'address' => 'Tax Street',
+        'title' => 'Tax home',
+        'price' => 300000,
+        'country' => 'GB',
+    ]);
+
+    $this->actingAs($user);
+    Livewire::component('test-property-tax-estimator', PropertyTaxEstimator::class);
+
+    Livewire::test('test-property-tax-estimator', ['propertyId' => $property->getKey()])
+        ->assertSee('Property tax estimate')
+        ->call('calculateTax')
+        ->assertSet('estimate.estimated', true)
+        ->assertSet('estimate.total_tax', 2500)
+        ->call('resetCalculation')
+        ->assertSet('estimate', null);
+});


### PR DESCRIPTION
Implements the next portable legacy parity slice across the modular architecture.\n\n- Adds estimate-only UK, US, and generic property transaction tax application service.\n- Exposes authenticated API and OpenAPI tax-estimate contract.\n- Adds tenant-scoped Livewire estimator and Filament action.\n- Adds architecture and feature coverage.\n\nFull suite: 308 passed, 12 skipped, 1591 assertions.