### PR TITLE
Complete saved property wishlist parity

### DIFF
--- a/modules/real-estate-properties-api/module.json
+++ b/modules/real-estate-properties-api/module.json
@@ -9,5 +9,5 @@
     "requires": {"php": "^8.5", "laravel": "^13.0", "packages": {"liberusoftware/real-estate-properties": "^1.0"}},
     "capabilities": ["real-estate.properties.api"],
     "default_enabled": true,
-    "features": ["Property list and detail transport", "Validated property creation", "Tenant-scoped property comparison", "Property tax estimates"]
+    "features": ["Property list and detail transport", "Validated property creation", "Tenant-scoped property comparison", "Property tax estimates", "Favorites and saved-property endpoints"]
 }

--- a/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
+++ b/modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml
@@ -50,6 +50,20 @@ paths:
                 buyer_type: {type: string, enum: [first_time_buyer, home_mover, additional_property]}
       responses:
         '200': {description: Estimated transaction costs; all figures are estimates}
+  /api/v1/real-estate/properties/favorites:
+    get:
+      operationId: real.estate.properties.favorites
+      security: [{sanctum: []}]
+      parameters:
+        - {name: search, in: query, schema: {type: string}}
+        - {name: sort_by, in: query, schema: {type: string, enum: [created_at, updated_at, price, year_built, bedrooms, bathrooms, area_sqft, address]}}
+        - {name: sort_direction, in: query, schema: {type: string, enum: [asc, desc]}}
+      responses: {'200': {description: Paginated saved properties}}
+  /api/v1/real-estate/properties/favorites/{id}:
+    delete:
+      operationId: real.estate.properties.favoriteRemove
+      security: [{sanctum: []}]
+      responses: {'200': {description: Favorite removed}}
   /api/v1/real-estate/properties/{id}:
     get:
       operationId: real.estate.properties.get

--- a/modules/real-estate-properties-api/routes/api.php
+++ b/modules/real-estate-properties-api/routes/api.php
@@ -10,8 +10,10 @@ Route::prefix('api/v1/real-estate/properties')->middleware(['api', 'auth:sanctum
     Route::post('/', [PropertyController::class, 'store'])->name('real-estate.properties.store');
     Route::get('/compare', [PropertyController::class, 'compare'])->name('real-estate.properties.compare');
     Route::post('/tax-estimate', [PropertyController::class, 'taxEstimate'])->name('real-estate.properties.tax-estimate');
+    Route::get('/favorites', [PropertyController::class, 'favorites'])->name('real-estate.properties.favorites');
     Route::post('/{property}/transition/{status}', [PropertyController::class, 'transition'])->name('real-estate.properties.transition');
     Route::post('/{property}/favorite', [PropertyController::class, 'favorite'])->name('real-estate.properties.favorite');
+    Route::delete('/favorites/{property}', [PropertyController::class, 'removeFavorite'])->name('real-estate.properties.favorite-remove');
     Route::get('/{property}/similar', [PropertyController::class, 'similar'])->name('real-estate.properties.similar');
     Route::put('/{property}/units', [PropertyController::class, 'unit'])->name('real-estate.properties.units');
     Route::post('/{property}/keys', [PropertyController::class, 'key'])->name('real-estate.properties.keys');

--- a/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
+++ b/modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php
@@ -14,6 +14,7 @@ use Liberu\RealEstate\Properties\Application\EstimatePropertyTax;
 use Liberu\RealEstate\Properties\Application\RecordPropertyKey;
 use Liberu\RealEstate\Properties\Application\TransitionProperty;
 use Liberu\RealEstate\Properties\Application\TogglePropertyFavorite;
+use Liberu\RealEstate\Properties\Application\RemovePropertyFavorite;
 use Liberu\RealEstate\Properties\Application\UpdateProperty;
 use Liberu\RealEstate\Properties\Application\UpsertPropertyUnit;
 use Liberu\RealEstate\Properties\Domain\PropertyStatus;
@@ -177,6 +178,31 @@ final class PropertyController
         abort_unless($user?->current_team_id === $property->team_id, 404);
 
         return response()->json(['favorited' => $toggle->handle($property->team_id, $user->getAuthIdentifier(), $property->getKey())]);
+    }
+
+    public function favorites(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        abort_unless($user?->current_team_id !== null, 403);
+        $filters = $request->validate([
+            'search' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'sort_by' => ['sometimes', 'nullable', Rule::in(['created_at', 'updated_at', 'price', 'year_built', 'bedrooms', 'bathrooms', 'area_sqft', 'address'])],
+            'sort_direction' => ['sometimes', 'nullable', Rule::in(['asc', 'desc'])],
+            'page_size' => ['sometimes', 'integer', 'min:1', 'max:100'],
+        ]);
+        $query = Property::query()->forTeam($user->current_team_id)
+            ->favoritedBy($user->current_team_id, $user->getAuthIdentifier())
+            ->search($filters['search'] ?? null);
+
+        return PropertyResource::collection($query->sorted($filters['sort_by'] ?? 'created_at', $filters['sort_direction'] ?? 'desc')->paginate($filters['page_size'] ?? 12)->withQueryString())->response();
+    }
+
+    public function removeFavorite(Request $request, Property $property, RemovePropertyFavorite $remove): JsonResponse
+    {
+        $user = $request->user();
+        abort_unless($user?->current_team_id === $property->team_id, 404);
+
+        return response()->json(['removed' => $remove->handle($property->team_id, $user->getAuthIdentifier(), $property->getKey())]);
     }
 
     public function similar(Request $request, Property $property): JsonResponse

--- a/modules/real-estate-properties-filament/module.json
+++ b/modules/real-estate-properties-filament/module.json
@@ -10,5 +10,5 @@
     "presentation": {"filament": {"admin": ["Liberu\\RealEstate\\PropertiesFilament\\PropertiesFilamentPlugin"]}},
     "capabilities": ["real-estate.properties.filament"],
     "default_enabled": true,
-    "features": ["Property resource", "Property category resource", "Property template resource", "Team-scoped property administration", "Property tax estimates"]
+    "features": ["Property resource", "Property category resource", "Property template resource", "Team-scoped property administration", "Property tax estimates", "Favorites filtering"]
 }

--- a/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
+++ b/modules/real-estate-properties-filament/src/Resources/PropertyResource.php
@@ -149,6 +149,11 @@ final class PropertyResource extends Resource
                         ->walkabilityScore($data['walkability_score'] ?? null)
                         ->transitScore($data['transit_score'] ?? null)
                         ->bikeScore($data['bike_score'] ?? null)),
+                Filter::make('favorites_only')
+                    ->label('My favorites')
+                    ->query(fn (Builder $query): Builder => auth()->user()?->current_team_id === null
+                        ? $query->whereRaw('1 = 0')
+                        : $query->favoritedBy(auth()->user()->current_team_id, auth()->id())),
             ])
             ->recordActions([
                 EditAction::make(),

--- a/modules/real-estate-properties-livewire/module.json
+++ b/modules/real-estate-properties-livewire/module.json
@@ -9,5 +9,5 @@
     "requires": {"php": "^8.5", "laravel": "^13.0", "packages": {"liberusoftware/real-estate-properties": "^1.0", "liberusoftware/real-estate-media-and-documents": "^1.0"}},
     "capabilities": ["real-estate.properties.livewire"],
     "default_enabled": true,
-    "features": ["Property search state", "Category filtering", "Template filtering", "Advanced bounded filters", "Validation and empty states", "Property detail disclosures", "Property gallery", "Property comparison", "Property tax estimates"]
+    "features": ["Property search state", "Category filtering", "Template filtering", "Advanced bounded filters", "Validation and empty states", "Property detail disclosures", "Property gallery", "Property comparison", "Property tax estimates", "Saved property wishlist"]
 }

--- a/modules/real-estate-properties-livewire/resources/views/wishlist-manager.blade.php
+++ b/modules/real-estate-properties-livewire/resources/views/wishlist-manager.blade.php
@@ -1,0 +1,26 @@
+<section aria-label="Saved properties">
+    <h2>Saved properties</h2>
+    <label for="wishlist-search">Search saved properties</label>
+    <input id="wishlist-search" type="search" wire:model.live="search">
+    <label for="wishlist-sort">Sort by</label>
+    <select id="wishlist-sort" wire:model.live="sortBy">
+        <option value="created_at">Recently saved</option>
+        <option value="title">Title</option>
+        <option value="price">Price</option>
+        <option value="address">Address</option>
+    </select>
+    @if ($removed)<p role="status">{{ $removed }}</p>@endif
+    <p aria-live="polite">{{ $totalFavorites }} saved properties.</p>
+    <ul aria-live="polite">
+        @forelse ($properties as $property)
+            <li wire:key="saved-property-{{ $property->getKey() }}">
+                <span>{{ $property->title ?: $property->address }}</span>
+                @if ($property->price !== null)<span>{{ $property->price }}</span>@endif
+                <button type="button" wire:click="removeFavorite({{ $property->getKey() }})">Remove</button>
+            </li>
+        @empty
+            <li>No saved properties yet. Search properties to add one to your shortlist.</li>
+        @endforelse
+    </ul>
+    {{ $properties->links() }}
+</section>

--- a/modules/real-estate-properties-livewire/src/Components/WishlistManager.php
+++ b/modules/real-estate-properties-livewire/src/Components/WishlistManager.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\PropertiesLivewire\Components;
+
+use Illuminate\Contracts\View\View;
+use Liberu\RealEstate\Properties\Application\RemovePropertyFavorite;
+use Liberu\RealEstate\Properties\Models\Property;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+final class WishlistManager extends Component
+{
+    use WithPagination;
+
+    public string $search = '';
+    public string $sortBy = 'created_at';
+    public ?string $removed = null;
+
+    protected $queryString = [
+        'search' => ['except' => ''],
+        'sortBy' => ['except' => 'created_at'],
+    ];
+
+    public function updatingSearch(): void
+    {
+        $this->removed = null;
+        $this->resetPage();
+    }
+
+    public function updatedSortBy(): void
+    {
+        $this->removed = null;
+        $this->resetPage();
+    }
+
+    public function removeFavorite(int $propertyId, RemovePropertyFavorite $remove): void
+    {
+        $user = auth()->user();
+        abort_unless($user?->current_team_id !== null, 403);
+        if ($remove->handle($user->current_team_id, $user->getAuthIdentifier(), $propertyId)) {
+            $this->removed = __('Removed from your shortlist.');
+            $this->resetPage();
+        }
+    }
+
+    public function render(): View
+    {
+        $user = auth()->user();
+        $properties = collect();
+        $totalFavorites = 0;
+
+        if ($user?->current_team_id !== null) {
+            $query = Property::query()
+                ->forTeam($user->current_team_id)
+                ->favoritedBy($user->current_team_id, $user->getAuthIdentifier())
+                ->search($this->search)
+                ->when(in_array($this->sortBy, Property::SORTABLE_COLUMNS, true), fn ($query) => $query->orderBy($this->sortBy, $this->sortBy === 'created_at' ? 'desc' : 'asc'));
+            $properties = $query->paginate(12);
+            $totalFavorites = Property::query()->forTeam($user->current_team_id)->favoritedBy($user->current_team_id, $user->getAuthIdentifier())->count();
+        }
+
+        return view('real-estate-properties-livewire::wishlist-manager', compact('properties', 'totalFavorites'));
+    }
+}

--- a/modules/real-estate-properties-livewire/src/PropertiesLivewireServiceProvider.php
+++ b/modules/real-estate-properties-livewire/src/PropertiesLivewireServiceProvider.php
@@ -17,6 +17,7 @@ final class PropertiesLivewireServiceProvider extends ServiceProvider
         Livewire::component('module-real-estate-properties::property-detail', Components\PropertyDetail::class);
         Livewire::component('module-real-estate-properties::property-comparison', Components\PropertyComparison::class);
         Livewire::component('module-real-estate-properties::property-tax-estimator', Components\PropertyTaxEstimator::class);
+        Livewire::component('module-real-estate-properties::wishlist-manager', Components\WishlistManager::class);
         Livewire::component('real-estate-properties-list', Components\PropertyList::class);
     }
 }

--- a/modules/real-estate-properties/src/Application/RemovePropertyFavorite.php
+++ b/modules/real-estate-properties/src/Application/RemovePropertyFavorite.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\Properties\Application;
+
+use Liberu\RealEstate\Properties\Models\PropertyFavorite;
+
+final class RemovePropertyFavorite
+{
+    public function handle(int|string $teamId, int|string $userId, int|string $propertyId): bool
+    {
+        return PropertyFavorite::query()
+            ->where('team_id', $teamId)
+            ->where('user_id', $userId)
+            ->where('property_id', $propertyId)
+            ->delete() > 0;
+    }
+}

--- a/modules/real-estate-properties/src/PropertiesServiceProvider.php
+++ b/modules/real-estate-properties/src/PropertiesServiceProvider.php
@@ -13,6 +13,8 @@ final class PropertiesServiceProvider extends ServiceProvider
         $this->app->singleton(Application\CreateProperty::class);
         $this->app->singleton(Application\UpsertPropertyUnit::class);
         $this->app->singleton(Application\RecordPropertyKey::class);
+        $this->app->singleton(Application\TogglePropertyFavorite::class);
+        $this->app->singleton(Application\RemovePropertyFavorite::class);
     }
 
     public function boot(): void

--- a/tests/Architecture/RealEstateCapabilityCoverageTest.php
+++ b/tests/Architecture/RealEstateCapabilityCoverageTest.php
@@ -263,6 +263,27 @@ it('keeps property tax estimates available across the modular adapters', functio
         ->toContain('EstimatePropertyTax');
 });
 
+it('keeps the legacy saved-property wishlist connected across property adapters', function (): void {
+    $core = file_get_contents(base_path('modules/real-estate-properties/src/Application/RemovePropertyFavorite.php'));
+    $api = file_get_contents(base_path('modules/real-estate-properties-api/src/Http/Controllers/PropertyController.php'));
+    $routes = file_get_contents(base_path('modules/real-estate-properties-api/routes/api.php'));
+    $openApi = file_get_contents(base_path('modules/real-estate-properties-api/openapi/v1/real-estate-properties.yaml'));
+    $component = file_get_contents(base_path('modules/real-estate-properties-livewire/src/Components/WishlistManager.php'));
+    $view = file_get_contents(base_path('modules/real-estate-properties-livewire/resources/views/wishlist-manager.blade.php'));
+    $provider = file_get_contents(base_path('modules/real-estate-properties-livewire/src/PropertiesLivewireServiceProvider.php'));
+    $filament = file_get_contents(base_path('modules/real-estate-properties-filament/src/Resources/PropertyResource.php'));
+
+    expect($core)->toContain('class RemovePropertyFavorite')->toContain('team_id')->toContain('user_id')
+        ->and($api)->toContain('public function favorites(Request $request)')->toContain('public function removeFavorite')
+        ->and($routes)->toContain("'/favorites'")->toContain("'/favorites/{property}'")
+        ->and($openApi)->toContain('/api/v1/real-estate/properties/favorites')
+        ->toContain('real.estate.properties.favorites')
+        ->and($component)->toContain('class WishlistManager')->toContain('removeFavorite')
+        ->and($view)->toContain('Saved properties')->toContain('No saved properties yet')
+        ->and($provider)->toContain("wishlist-manager', Components\\WishlistManager::class")
+        ->and($filament)->toContain("Filter::make('favorites_only')")->toContain('favoritedBy');
+});
+
 it('keeps Filament resources tenant-scoped and lifecycle-delegated', function (): void {
     $root = dirname(__DIR__, 2);
 

--- a/tests/Feature/RealEstatePropertyActionsTest.php
+++ b/tests/Feature/RealEstatePropertyActionsTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Models\User;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Validation\ValidationException;
 use Liberu\RealEstate\Core\Application\CreateBranch;
 use Liberu\RealEstate\Properties\Application\CreateProperty;
@@ -413,6 +415,34 @@ it('supports tenant and user-scoped property favorites', function (): void {
         ->and(app(\Liberu\RealEstate\Properties\Application\TogglePropertyFavorite::class)->handle(10, 20, $property->getKey()))->toBeFalse()
         ->and(Property::query()->forTeam(10)->favoritedBy(10, 20)->exists())->toBeFalse()
         ->and(fn () => app(\Liberu\RealEstate\Properties\Application\TogglePropertyFavorite::class)->handle(11, 20, $otherUserProperty->getKey()))->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+});
+
+it('serves a searchable saved-property wishlist through API and Livewire', function (): void {
+    $user = User::factory()->create(['current_team_id' => 10]);
+    RateLimiter::for('api', static fn (): Limit => Limit::perMinute(1000));
+    $property = app(CreateProperty::class)->handle(10, $user->getAuthIdentifier(), ['address' => '1 Saved Street', 'title' => 'Saved home', 'price' => 250000]);
+    app(\Liberu\RealEstate\Properties\Application\TogglePropertyFavorite::class)->handle(10, $user->getAuthIdentifier(), $property->getKey());
+
+    $this->actingAs($user, 'sanctum')
+        ->getJson('/api/v1/real-estate/properties/favorites?search=Saved')
+        ->assertOk()
+        ->assertJsonPath('data.0.title', 'Saved home')
+        ->assertJsonPath('data.0.is_favorited', true);
+
+    $this->deleteJson('/api/v1/real-estate/properties/favorites/'.$property->getKey())
+        ->assertOk()
+        ->assertJsonPath('removed', true);
+
+    $property = app(CreateProperty::class)->handle(10, $user->getAuthIdentifier(), ['address' => '2 Shortlist Street', 'title' => 'Shortlist home']);
+    app(\Liberu\RealEstate\Properties\Application\TogglePropertyFavorite::class)->handle(10, $user->getAuthIdentifier(), $property->getKey());
+    $this->actingAs($user);
+    Livewire::component('test-wishlist-manager', \Liberu\RealEstate\PropertiesLivewire\Components\WishlistManager::class);
+
+    Livewire::test('test-wishlist-manager')
+        ->assertSee('Shortlist home')
+        ->call('removeFavorite', $property->getKey())
+        ->assertSee('Removed from your shortlist.')
+        ->assertSee('No saved properties yet');
 });
 
 it('preserves legacy similar-property matching within the property boundary', function (): void {


### PR DESCRIPTION
Carries the legacy saved-property wishlist into the modular boundary: team-scoped favorite removal, searchable/paginated favorites API endpoints, a Livewire wishlist manager, and a Filament favorites filter. Includes architecture and feature coverage. Standalone properties module PRs were merged first.