### PR TITLE
Improve localized document templates and signing workflows

### DIFF
--- a/modules/real-estate-media-and-documents/README.md
+++ b/modules/real-estate-media-and-documents/README.md
@@ -1,5 +1,11 @@
 # Real Estate Media and Documents
 
+## Document template catalogue
+
+The module includes a small catalogue of copyable demonstration templates via `DocumentTemplateCatalogue`. It includes UK-focused residential tenancy and sales memorandum examples, plus jurisdiction-neutral versions suitable for localization to Spanish, Italian, French, German, Portuguese, Russian, Tajik or Uzbek workflows. Demonstrations are intentionally not seeded automatically: templates belong to a team and must be copied after legal review.
+
+Every legal template is marked as a demonstration, uses explicit variables and sections, and keeps the governing-law text configurable. UK examples are illustrative only and should be reviewed against the current law and the property's jurisdiction.
+
 Provider-neutral media and document records for photos, floorplans, video, certificates, brochures, rights, ordering, retention, reusable transaction templates, and digital signing. The package name is `liberusoftware/real-estate-media-and-documents`; its source repository intentionally uses the `module-` prefix.
 
 ## Transaction document pattern

--- a/modules/real-estate-media-and-documents/config/document-templates.php
+++ b/modules/real-estate-media-and-documents/config/document-templates.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'demonstrations' => [
+        [
+            'slug' => 'uk-tenancy-agreement-demo',
+            'name' => 'UK Residential Tenancy Agreement (Demonstration)',
+            'description' => 'A structured UK-focused example for product demonstrations. It is not legal advice and must be reviewed for the property and current law.',
+            'document_type' => 'tenancy_agreement',
+            'locale' => 'en-GB',
+            'variables' => ['landlord_name', 'tenant_name', 'property_address', 'start_date', 'fixed_term', 'rent_amount', 'rent_frequency', 'deposit_amount', 'governing_law'],
+            'sections' => ['parties', 'property', 'term', 'rent_and_deposit', 'repair_and_access', 'ending_the_tenancy', 'signatures'],
+            'content' => <<<'TEMPLATE'
+UK RESIDENTIAL TENANCY AGREEMENT — DEMONSTRATION ONLY
+
+This example is provided for software demonstrations and is not a prescribed form or legal advice. Obtain current professional advice before use.
+
+1. Parties
+Landlord: {{ landlord_name }}
+Tenant: {{ tenant_name }}
+
+2. Property
+The property is {{ property_address }}.
+
+3. Term
+The tenancy starts on {{ start_date }} and continues for {{ fixed_term }}.
+
+4. Rent and deposit
+Rent: {{ rent_amount }} {{ rent_frequency }}.
+Deposit: {{ deposit_amount }}. Any deposit handling must comply with the applicable scheme and law.
+
+5. General terms
+The parties should record repair, access, permitted use, notice, safety, privacy and inventory arrangements in the final reviewed agreement.
+
+6. Governing law
+{{ governing_law }}. The applicable jurisdiction and statutory requirements must be confirmed before signing.
+
+Landlord signature: ____________________    Date: __________
+Tenant signature: ______________________    Date: __________
+TEMPLATE,
+        ],
+        [
+            'slug' => 'uk-sales-memorandum-demo',
+            'name' => 'UK Sales Memorandum (Demonstration)',
+            'description' => 'A UK-focused, non-contractual sales memorandum example for demonstrations. It is subject to contract and legal review.',
+            'document_type' => 'sales_memorandum',
+            'locale' => 'en-GB',
+            'variables' => ['seller_name', 'buyer_name', 'property_address', 'asking_price', 'agreed_price', 'agent_name', 'special_conditions'],
+            'sections' => ['parties', 'property', 'price', 'conditions', 'important_notice', 'acknowledgement'],
+            'content' => <<<'TEMPLATE'
+MEMORANDUM OF SALE — DEMONSTRATION ONLY
+
+This memorandum records the current understanding of the parties. It is not a contract, is subject to contract, and does not create a binding obligation to sell or purchase.
+
+Seller: {{ seller_name }}
+Buyer: {{ buyer_name }}
+Property: {{ property_address }}
+Agent: {{ agent_name }}
+Asking price: {{ asking_price }}
+Agreed price: {{ agreed_price }}
+Special conditions or notes: {{ special_conditions }}
+
+The parties should obtain independent legal advice and confirm title, fixtures and fittings, services, inclusions, chain information, searches, finance, exchange and completion arrangements in the contract documentation.
+
+Seller acknowledgement: ____________________    Date: __________
+Buyer acknowledgement: _____________________    Date: __________
+TEMPLATE,
+        ],
+        [
+            'slug' => 'generic-tenancy-agreement-demo',
+            'name' => 'Residential Tenancy Agreement (Generic Demonstration)',
+            'description' => 'A jurisdiction-neutral tenancy example. Replace the governing-law and statutory sections for the selected locale.',
+            'document_type' => 'tenancy_agreement',
+            'locale' => 'en',
+            'variables' => ['landlord_name', 'tenant_name', 'property_address', 'start_date', 'term', 'rent_amount', 'deposit_amount', 'governing_law'],
+            'sections' => ['parties', 'property', 'term', 'payments', 'responsibilities', 'ending', 'signatures'],
+            'content' => <<<'TEMPLATE'
+RESIDENTIAL TENANCY AGREEMENT — GENERIC DEMONSTRATION
+
+This is a software demonstration template, not legal advice. Adapt it to the laws and required notices of the property's jurisdiction before use.
+
+Landlord: {{ landlord_name }}
+Tenant: {{ tenant_name }}
+Property: {{ property_address }}
+Start date: {{ start_date }}
+Term: {{ term }}
+Rent: {{ rent_amount }}
+Deposit: {{ deposit_amount }}
+Governing law: {{ governing_law }}
+
+The final agreement should address habitability, repairs, access, permitted use, privacy, payments, deposit protection, notices, dispute resolution and termination according to local law.
+
+Landlord signature: ____________________    Date: __________
+Tenant signature: ______________________    Date: __________
+TEMPLATE,
+        ],
+        [
+            'slug' => 'generic-sales-memorandum-demo',
+            'name' => 'Sales Memorandum (Generic Demonstration)',
+            'description' => 'A jurisdiction-neutral memorandum of sale example, suitable as a starting point for localized sales workflows.',
+            'document_type' => 'sales_memorandum',
+            'locale' => 'en',
+            'variables' => ['seller_name', 'buyer_name', 'property_address', 'price', 'agent_name', 'conditions', 'governing_law'],
+            'sections' => ['parties', 'property', 'price', 'conditions', 'status', 'acknowledgement'],
+            'content' => <<<'TEMPLATE'
+MEMORANDUM OF SALE — GENERIC DEMONSTRATION
+
+This document records preliminary commercial terms only. It is not a contract unless the applicable law expressly provides otherwise.
+
+Seller: {{ seller_name }}
+Buyer: {{ buyer_name }}
+Property: {{ property_address }}
+Price: {{ price }}
+Agent: {{ agent_name }}
+Conditions: {{ conditions }}
+Governing law: {{ governing_law }}
+
+The parties should use locally reviewed contract documents for title, disclosures, searches, finance, exchange, completion and any cooling-off or consumer rights.
+
+Seller acknowledgement: ____________________    Date: __________
+Buyer acknowledgement: _____________________    Date: __________
+TEMPLATE,
+        ],
+    ],
+];

--- a/modules/real-estate-media-and-documents/module.json
+++ b/modules/real-estate-media-and-documents/module.json
@@ -10,5 +10,5 @@
     "suggests": {},
     "capabilities": ["real-estate.media-and-documents"],
     "default_enabled": true,
-    "features": ["Photos", "Floorplans", "Site plans", "Video", "Certificates", "Rights", "Ordering", "Brochures", "Retention"]
+    "features": ["Photos", "Floorplans", "Site plans", "Video", "Certificates", "Rights", "Ordering", "Brochures", "Retention", "Versioned templates", "Localized demonstrations", "Signing envelopes", "Digital signatures", "Signing audit trail"]
 }

--- a/modules/real-estate-media-and-documents/src/Application/CreateDocumentEnvelope.php
+++ b/modules/real-estate-media-and-documents/src/Application/CreateDocumentEnvelope.php
@@ -22,6 +22,7 @@ final class CreateDocumentEnvelope
             throw ValidationException::withMessages(['template' => 'Only a published template from the current team can be used.']);
         }
 
+        $template->validateValues($values);
         $content = $template->generateDocument($values);
 
         return DB::transaction(function () use ($teamId, $actorId, $template, $values, $content, $participants): DocumentEnvelope {

--- a/modules/real-estate-media-and-documents/src/Application/DocumentTemplateCatalogue.php
+++ b/modules/real-estate-media-and-documents/src/Application/DocumentTemplateCatalogue.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\RealEstate\MediaAndDocuments\Application;
+
+final class DocumentTemplateCatalogue
+{
+    /**
+     * Return safe demonstration templates that can be copied into a team's library.
+     * They are deliberately not seeded automatically because templates are team-owned.
+     */
+    public function demonstrations(): array
+    {
+        return config('document-templates.demonstrations', []);
+    }
+
+    public function for(string $documentType, ?string $locale = null): array
+    {
+        return array_values(array_filter(
+            $this->demonstrations(),
+            static fn (array $template): bool => $template['document_type'] === $documentType
+                && ($locale === null || $template['locale'] === $locale),
+        ));
+    }
+}

--- a/modules/real-estate-media-and-documents/src/MediaAndDocumentsServiceProvider.php
+++ b/modules/real-estate-media-and-documents/src/MediaAndDocumentsServiceProvider.php
@@ -10,6 +10,9 @@ final class MediaAndDocumentsServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
+        $this->mergeConfigFrom(__DIR__.'/../config/document-templates.php', 'document-templates');
+
+        $this->app->singleton(Application\DocumentTemplateCatalogue::class);
         $this->app->singleton(Application\GeneratePropertyBrochure::class);
         $this->app->singleton(Application\CreateHomeReport::class);
         $this->app->singleton(Application\UpdateHomeReportConditions::class);

--- a/modules/real-estate-media-and-documents/src/Models/DocumentTemplate.php
+++ b/modules/real-estate-media-and-documents/src/Models/DocumentTemplate.php
@@ -40,16 +40,19 @@ final class DocumentTemplate extends Model
 
     public function renderContent(array $values): string
     {
+        return (string) preg_replace_callback(
+            '/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/',
+            fn (array $match): string => e((string) ($values[$match[1]] ?? '')),
+            $this->content,
+        );
+    }
+
+    public function validateValues(array $values): void
+    {
         $missing = array_values(array_diff($this->getCustomFields(), array_keys($values)));
         if ($missing !== []) {
             throw ValidationException::withMessages(['values' => 'Missing template values: '.implode(', ', $missing)]);
         }
-
-        return (string) preg_replace_callback(
-            '/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/',
-            fn (array $match): string => e((string) $values[$match[1]]),
-            $this->content,
-        );
     }
 
     public function generateDocument(array $values): string

--- a/tests/Feature/RealEstateDocumentTemplatesTest.php
+++ b/tests/Feature/RealEstateDocumentTemplatesTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Liberu\RealEstate\MediaAndDocuments\Application\DocumentTemplateCatalogue;
 use Liberu\RealEstate\MediaAndDocuments\Models\DocumentCategory;
 use Liberu\RealEstate\MediaAndDocuments\Models\DocumentTemplate;
 use Liberu\RealEstate\MediaAndDocuments\Models\MediaDocument;
@@ -23,4 +24,15 @@ it('extracts and safely replaces document template fields', function (): void {
     expect($template->getCustomFields())->toBe(['recipient', 'amount'])
         ->and($template->generateDocument(['recipient' => '<Buyer>', 'amount' => '£300,000']))->toContain('&lt;Buyer&gt;')->toContain('£300,000')
         ->and($template->renderContent(['recipient' => 'Buyer']))->toContain('Buyer');
+});
+
+it('provides UK and generic demonstrations for the document workflow', function (): void {
+    $catalogue = app(DocumentTemplateCatalogue::class);
+
+    expect($catalogue->for('tenancy_agreement', 'en-GB'))->toHaveCount(1)
+        ->and($catalogue->for('sales_memorandum', 'en-GB'))->toHaveCount(1)
+        ->and($catalogue->for('tenancy_agreement', 'en'))->toHaveCount(1)
+        ->and($catalogue->demonstrations())->each->toHaveKeys([
+            'slug', 'name', 'description', 'document_type', 'locale', 'variables', 'sections', 'content',
+        ]);
 });


### PR DESCRIPTION
## Summary\n- add UK-focused tenancy agreement and sales memorandum demonstrations\n- add jurisdiction-neutral templates with explicit variables and sections\n- expose a team-copyable document template catalogue\n- preserve legacy rendering while enforcing complete values when creating signing envelopes\n\n## Validation\n- php artisan test tests/Feature/RealEstateDocumentTemplatesTest.php\n- vendor/bin/pint --test ...\n\nDemonstration templates are explicitly marked for legal review and are not legal advice.