### PR TITLE
Upgrade application dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -238,9 +238,9 @@
         "spatie/laravel-activitylog": "^5.0",
         "spatie/laravel-backup": "^10.3",
         "spatie/laravel-passkeys": "^1.6",
-        "spatie/laravel-permission": "^7.0",
+        "spatie/laravel-permission": "^8.0",
         "spiral/roadrunner-cli": "^2.6.0",
-        "spiral/roadrunner-http": "^3.3.0"
+        "spiral/roadrunner-http": "^4.1.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "893639d219f9da178f5e465942bba4a5",
+    "content-hash": "a51da76827698cc6f24d150acb352ae6",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -649,16 +649,16 @@
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon-doctrine-types.git",
-                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d"
+                "reference": "5fa5eacafd9ef47c8c6ab9143fc901ba0194d3dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon-doctrine-types/zipball/18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
-                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon-doctrine-types/zipball/5fa5eacafd9ef47c8c6ab9143fc901ba0194d3dc",
+                "reference": "5fa5eacafd9ef47c8c6ab9143fc901ba0194d3dc",
                 "shasum": ""
             },
             "require": {
@@ -673,6 +673,11 @@
                 "phpunit/phpunit": "^10.3"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Carbon\\Doctrine\\": "src/Carbon/Doctrine/"
@@ -698,7 +703,7 @@
             ],
             "support": {
                 "issues": "https://github.com/CarbonPHP/carbon-doctrine-types/issues",
-                "source": "https://github.com/CarbonPHP/carbon-doctrine-types/tree/3.2.0"
+                "source": "https://github.com/CarbonPHP/carbon-doctrine-types/tree/3.2.1"
             },
             "funding": [
                 {
@@ -714,7 +719,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-09T16:56:22+00:00"
+            "time": "2026-09-06T14:11:38+00:00"
         },
         {
             "name": "chillerlan/php-qrcode",
@@ -2207,16 +2212,16 @@
         },
         {
             "name": "filament/actions",
-            "version": "v5.7.6",
+            "version": "v5.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/actions.git",
-                "reference": "da3ed6cc03bd604b8b875ea03d4e9ef02c279eb2"
+                "reference": "cc84d88a7318eb1faae39cb5f36191ccc3b81334"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/actions/zipball/da3ed6cc03bd604b8b875ea03d4e9ef02c279eb2",
-                "reference": "da3ed6cc03bd604b8b875ea03d4e9ef02c279eb2",
+                "url": "https://api.github.com/repos/filamentphp/actions/zipball/cc84d88a7318eb1faae39cb5f36191ccc3b81334",
+                "reference": "cc84d88a7318eb1faae39cb5f36191ccc3b81334",
                 "shasum": ""
             },
             "require": {
@@ -2252,20 +2257,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-08-05T20:45:04+00:00"
+            "time": "2026-08-31T17:03:02+00:00"
         },
         {
             "name": "filament/filament",
-            "version": "v5.7.6",
+            "version": "v5.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/panels.git",
-                "reference": "7e75d8da9b907ead7d618ce8237228316d08ae43"
+                "reference": "16adb1532c639739944a2acea959e16ac100e093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/panels/zipball/7e75d8da9b907ead7d618ce8237228316d08ae43",
-                "reference": "7e75d8da9b907ead7d618ce8237228316d08ae43",
+                "url": "https://api.github.com/repos/filamentphp/panels/zipball/16adb1532c639739944a2acea959e16ac100e093",
+                "reference": "16adb1532c639739944a2acea959e16ac100e093",
                 "shasum": ""
             },
             "require": {
@@ -2309,20 +2314,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-08-05T20:52:57+00:00"
+            "time": "2026-08-31T17:09:06+00:00"
         },
         {
             "name": "filament/forms",
-            "version": "v5.7.6",
+            "version": "v5.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/forms.git",
-                "reference": "3295b3acfe81dc75faa3a6dbbfea551e4df10887"
+                "reference": "ea0a0ee11efca648a043f9b3ff4113e54dadb7b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/forms/zipball/3295b3acfe81dc75faa3a6dbbfea551e4df10887",
-                "reference": "3295b3acfe81dc75faa3a6dbbfea551e4df10887",
+                "url": "https://api.github.com/repos/filamentphp/forms/zipball/ea0a0ee11efca648a043f9b3ff4113e54dadb7b0",
+                "reference": "ea0a0ee11efca648a043f9b3ff4113e54dadb7b0",
                 "shasum": ""
             },
             "require": {
@@ -2359,20 +2364,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-08-05T20:51:04+00:00"
+            "time": "2026-08-31T17:04:14+00:00"
         },
         {
             "name": "filament/infolists",
-            "version": "v5.7.6",
+            "version": "v5.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/infolists.git",
-                "reference": "dca2f115006b716f2293e29042f9c9b410fc3548"
+                "reference": "0a8ca9b6cc60f7179de87b0ad9c2f787bbbd2d29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/dca2f115006b716f2293e29042f9c9b410fc3548",
-                "reference": "dca2f115006b716f2293e29042f9c9b410fc3548",
+                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/0a8ca9b6cc60f7179de87b0ad9c2f787bbbd2d29",
+                "reference": "0a8ca9b6cc60f7179de87b0ad9c2f787bbbd2d29",
                 "shasum": ""
             },
             "require": {
@@ -2404,20 +2409,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-08-05T20:44:03+00:00"
+            "time": "2026-08-31T17:09:57+00:00"
         },
         {
             "name": "filament/notifications",
-            "version": "v5.7.6",
+            "version": "v5.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/notifications.git",
-                "reference": "f188823f2e681883e1fa419af7e2f2a17d4c63c5"
+                "reference": "95d7d4730152353fbcd7365ee890022707382de7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/notifications/zipball/f188823f2e681883e1fa419af7e2f2a17d4c63c5",
-                "reference": "f188823f2e681883e1fa419af7e2f2a17d4c63c5",
+                "url": "https://api.github.com/repos/filamentphp/notifications/zipball/95d7d4730152353fbcd7365ee890022707382de7",
+                "reference": "95d7d4730152353fbcd7365ee890022707382de7",
                 "shasum": ""
             },
             "require": {
@@ -2451,20 +2456,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-08-05T20:49:13+00:00"
+            "time": "2026-08-31T17:08:43+00:00"
         },
         {
             "name": "filament/query-builder",
-            "version": "v5.7.6",
+            "version": "v5.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/query-builder.git",
-                "reference": "d658205b135ef364c992f5d5d518e9463099aab4"
+                "reference": "900b00b9dd5162c929aee540888c66883e7dd832"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/query-builder/zipball/d658205b135ef364c992f5d5d518e9463099aab4",
-                "reference": "d658205b135ef364c992f5d5d518e9463099aab4",
+                "url": "https://api.github.com/repos/filamentphp/query-builder/zipball/900b00b9dd5162c929aee540888c66883e7dd832",
+                "reference": "900b00b9dd5162c929aee540888c66883e7dd832",
                 "shasum": ""
             },
             "require": {
@@ -2497,20 +2502,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-08-05T20:44:12+00:00"
+            "time": "2026-08-31T17:03:51+00:00"
         },
         {
             "name": "filament/schemas",
-            "version": "v5.7.6",
+            "version": "v5.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/schemas.git",
-                "reference": "3e191f49090645685a34560f5a3e1ba28ed3e7bc"
+                "reference": "890fa9f369267f8a002ec6ea2313586b1f54cddb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/schemas/zipball/3e191f49090645685a34560f5a3e1ba28ed3e7bc",
-                "reference": "3e191f49090645685a34560f5a3e1ba28ed3e7bc",
+                "url": "https://api.github.com/repos/filamentphp/schemas/zipball/890fa9f369267f8a002ec6ea2313586b1f54cddb",
+                "reference": "890fa9f369267f8a002ec6ea2313586b1f54cddb",
                 "shasum": ""
             },
             "require": {
@@ -2542,20 +2547,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-08-05T20:51:01+00:00"
+            "time": "2026-08-31T17:09:38+00:00"
         },
         {
             "name": "filament/spatie-laravel-settings-plugin",
-            "version": "v5.7.6",
+            "version": "v5.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-settings-plugin.git",
-                "reference": "82ffb2fdc26747ca103e789e3d56252612ffad6a"
+                "reference": "1fdffbe407e2d0cb98fd6c42eebeedea961b3b32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/spatie-laravel-settings-plugin/zipball/82ffb2fdc26747ca103e789e3d56252612ffad6a",
-                "reference": "82ffb2fdc26747ca103e789e3d56252612ffad6a",
+                "url": "https://api.github.com/repos/filamentphp/spatie-laravel-settings-plugin/zipball/1fdffbe407e2d0cb98fd6c42eebeedea961b3b32",
+                "reference": "1fdffbe407e2d0cb98fd6c42eebeedea961b3b32",
                 "shasum": ""
             },
             "require": {
@@ -2586,20 +2591,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-08-05T20:48:23+00:00"
+            "time": "2026-08-31T17:04:36+00:00"
         },
         {
             "name": "filament/support",
-            "version": "v5.7.6",
+            "version": "v5.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/support.git",
-                "reference": "b6a33dd2af46160abe73226d671b1bc490a84a27"
+                "reference": "db044fa876c998aa55b867f5774a4eb5b42c75ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/support/zipball/b6a33dd2af46160abe73226d671b1bc490a84a27",
-                "reference": "b6a33dd2af46160abe73226d671b1bc490a84a27",
+                "url": "https://api.github.com/repos/filamentphp/support/zipball/db044fa876c998aa55b867f5774a4eb5b42c75ea",
+                "reference": "db044fa876c998aa55b867f5774a4eb5b42c75ea",
                 "shasum": ""
             },
             "require": {
@@ -2644,20 +2649,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-08-05T20:51:57+00:00"
+            "time": "2026-09-01T08:40:00+00:00"
         },
         {
             "name": "filament/tables",
-            "version": "v5.7.6",
+            "version": "v5.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/tables.git",
-                "reference": "be471ed4a9f2e7dcbbb134db622a03d4e89f7a21"
+                "reference": "71c498959168c0a60b6cbe754c216a3a1f0ec623"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/tables/zipball/be471ed4a9f2e7dcbbb134db622a03d4e89f7a21",
-                "reference": "be471ed4a9f2e7dcbbb134db622a03d4e89f7a21",
+                "url": "https://api.github.com/repos/filamentphp/tables/zipball/71c498959168c0a60b6cbe754c216a3a1f0ec623",
+                "reference": "71c498959168c0a60b6cbe754c216a3a1f0ec623",
                 "shasum": ""
             },
             "require": {
@@ -2690,20 +2695,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-08-05T20:51:25+00:00"
+            "time": "2026-08-31T17:09:20+00:00"
         },
         {
             "name": "filament/widgets",
-            "version": "v5.7.6",
+            "version": "v5.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/widgets.git",
-                "reference": "e500c98debe26112008398933fcf3ed50ee103f7"
+                "reference": "ce0718e8c0aced904fb9f09be03f4fb33f8dcde6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/widgets/zipball/e500c98debe26112008398933fcf3ed50ee103f7",
-                "reference": "e500c98debe26112008398933fcf3ed50ee103f7",
+                "url": "https://api.github.com/repos/filamentphp/widgets/zipball/ce0718e8c0aced904fb9f09be03f4fb33f8dcde6",
+                "reference": "ce0718e8c0aced904fb9f09be03f4fb33f8dcde6",
                 "shasum": ""
             },
             "require": {
@@ -2734,7 +2739,7 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-08-05T20:49:46+00:00"
+            "time": "2026-08-31T17:10:07+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -2875,16 +2880,16 @@
         },
         {
             "name": "google/protobuf",
-            "version": "v5.36.0",
+            "version": "v5.36.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "9c105104b54709ecd902494ab340ed2122789b2d"
+                "reference": "d64d16befba8632967f604b9644c0bb8f64cfbc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/9c105104b54709ecd902494ab340ed2122789b2d",
-                "reference": "9c105104b54709ecd902494ab340ed2122789b2d",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/d64d16befba8632967f604b9644c0bb8f64cfbc3",
+                "reference": "d64d16befba8632967f604b9644c0bb8f64cfbc3",
                 "shasum": ""
             },
             "require": {
@@ -2913,9 +2918,9 @@
                 "proto"
             ],
             "support": {
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v5.36.0"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v5.36.1"
             },
-            "time": "2026-08-20T13:06:50+00:00"
+            "time": "2026-08-31T22:07:31+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -4975,16 +4980,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.29.0",
+            "version": "v13.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "6e2c363716964d8238cee7097b258119a984f0cf"
+                "reference": "718d17db56861e0a49f644217c8853dab1bff8ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/6e2c363716964d8238cee7097b258119a984f0cf",
-                "reference": "6e2c363716964d8238cee7097b258119a984f0cf",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/718d17db56861e0a49f644217c8853dab1bff8ce",
+                "reference": "718d17db56861e0a49f644217c8853dab1bff8ce",
                 "shasum": ""
             },
             "require": {
@@ -5198,7 +5203,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-08-25T20:57:16+00:00"
+            "time": "2026-09-01T21:42:30+00:00"
         },
         {
             "name": "laravel/horizon",
@@ -5912,22 +5917,22 @@
         },
         {
             "name": "laravel/socialite",
-            "version": "v5.30.1",
+            "version": "v5.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/socialite.git",
-                "reference": "5c79f43e48d518f0e82dff0a03009c4cbe794c4e"
+                "reference": "f721b2cbec327ab820bd6aabea6ab211cfcc9f08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/socialite/zipball/5c79f43e48d518f0e82dff0a03009c4cbe794c4e",
-                "reference": "5c79f43e48d518f0e82dff0a03009c4cbe794c4e",
+                "url": "https://api.github.com/repos/laravel/socialite/zipball/f721b2cbec327ab820bd6aabea6ab211cfcc9f08",
+                "reference": "f721b2cbec327ab820bd6aabea6ab211cfcc9f08",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "firebase/php-jwt": "^6.4|^7.0",
-                "guzzlehttp/guzzle": "^6.0|^7.0",
+                "guzzlehttp/guzzle": "^6.0|^7.0|^8.0",
                 "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
                 "illuminate/http": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
                 "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
@@ -5980,20 +5985,20 @@
                 "issues": "https://github.com/laravel/socialite/issues",
                 "source": "https://github.com/laravel/socialite"
             },
-            "time": "2026-08-24T13:31:12+00:00"
+            "time": "2026-08-31T13:49:19+00:00"
         },
         {
             "name": "laravel/telescope",
-            "version": "v5.22.1",
+            "version": "v5.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/telescope.git",
-                "reference": "67edf6caba0f6f9421a92c38bf97e369af268a56"
+                "reference": "82c84e1037540261f05060a5ae435a5ec982af91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/telescope/zipball/67edf6caba0f6f9421a92c38bf97e369af268a56",
-                "reference": "67edf6caba0f6f9421a92c38bf97e369af268a56",
+                "url": "https://api.github.com/repos/laravel/telescope/zipball/82c84e1037540261f05060a5ae435a5ec982af91",
+                "reference": "82c84e1037540261f05060a5ae435a5ec982af91",
                 "shasum": ""
             },
             "require": {
@@ -6006,10 +6011,10 @@
             },
             "require-dev": {
                 "ext-gd": "*",
-                "guzzlehttp/guzzle": "^6.0|^7.0",
+                "guzzlehttp/guzzle": "^6.0|^7.0|^8.0",
                 "laravel/octane": "^1.4|^2.0",
-                "orchestra/testbench": "^6.47.1|^7.55|^8.36|^9.15|^10.8|^11.0",
-                "phpstan/phpstan": "^1.10"
+                "orchestra/testbench": "^6.48|^7.57|^8.38|^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^2.2.9"
             },
             "type": "library",
             "extra": {
@@ -6046,10 +6051,9 @@
                 "monitoring"
             ],
             "support": {
-                "issues": "https://github.com/laravel/telescope/issues",
-                "source": "https://github.com/laravel/telescope/tree/v5.22.1"
+                "source": "https://github.com/laravel/telescope/tree/v5.23.0"
             },
-            "time": "2026-08-05T13:51:24+00:00"
+            "time": "2026-08-27T20:20:50+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -6468,16 +6472,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.35.3",
+            "version": "3.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "5fc8404762179ae514678487b23494fd69b2309c"
+                "reference": "f7fb152932f30072d573510cbd4dd657d6475b25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/5fc8404762179ae514678487b23494fd69b2309c",
-                "reference": "5fc8404762179ae514678487b23494fd69b2309c",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/f7fb152932f30072d573510cbd4dd657d6475b25",
+                "reference": "f7fb152932f30072d573510cbd4dd657d6475b25",
                 "shasum": ""
             },
             "require": {
@@ -6545,9 +6549,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.35.3"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.36.0"
             },
-            "time": "2026-08-22T12:55:54+00:00"
+            "time": "2026-09-02T08:00:27+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -7047,16 +7051,10 @@
         {
             "name": "liberusoftware/activity-comments-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-activity-comments-api.git",
-                "reference": "5fa38636a95c6143c864a5c4939f40325839ac29"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-activity-comments-api/zipball/5fa38636a95c6143c864a5c4939f40325839ac29",
-                "reference": "5fa38636a95c6143c864a5c4939f40325839ac29",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/activity-comments-api",
+                "reference": "ef7b7dad92ac27627f6884a28c515062e714df9f"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -7082,30 +7080,32 @@
                     "Liberu\\Foundation\\ActivityCommentsApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ActivityCommentsApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Activity and Comments api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-activity-comments-api/issues",
-                "source": "https://github.com/liberusoftware/module-activity-comments-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T01:58:57+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/activity-comments-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-activity-comments-filament.git",
-                "reference": "f2e07fbcf61e80f639cdeb79b230466cf1ab1eab"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-activity-comments-filament/zipball/f2e07fbcf61e80f639cdeb79b230466cf1ab1eab",
-                "reference": "f2e07fbcf61e80f639cdeb79b230466cf1ab1eab",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/activity-comments-filament",
+                "reference": "2d92ea30f1b13727120fc40ef0cdbed7512b71a2"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -7130,30 +7130,32 @@
                     "Liberu\\Foundation\\ActivityCommentsFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ActivityCommentsFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Activity and Comments filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-activity-comments-filament/issues",
-                "source": "https://github.com/liberusoftware/module-activity-comments-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:01+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/activity-comments-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-activity-comments-livewire.git",
-                "reference": "101969435c22b2bc6025d4b815a0f5fcdb3dc43e"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-activity-comments-livewire/zipball/101969435c22b2bc6025d4b815a0f5fcdb3dc43e",
-                "reference": "101969435c22b2bc6025d4b815a0f5fcdb3dc43e",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/activity-comments-livewire",
+                "reference": "b03e240b8f1e113c4be619523d1eb20976acd97f"
             },
             "require": {
                 "liberusoftware/activity-comments": "^1.0",
@@ -7178,16 +7180,24 @@
                     "Liberu\\Foundation\\ActivityCommentsLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ActivityCommentsLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Activity and Comments livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-activity-comments-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-activity-comments-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:34+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/analytics-contracts",
@@ -7275,16 +7285,10 @@
         {
             "name": "liberusoftware/analytics-core-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-analytics-core-api.git",
-                "reference": "13492231b93347dd16604f81d8ba2c1588254b07"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-analytics-core-api/zipball/13492231b93347dd16604f81d8ba2c1588254b07",
-                "reference": "13492231b93347dd16604f81d8ba2c1588254b07",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/analytics-core-api",
+                "reference": "4a21c29f70aef97f7aeaf82ea6b8987719f13e7e"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -7310,30 +7314,32 @@
                     "Liberu\\Foundation\\AnalyticsCoreApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\AnalyticsCoreApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Analytics Core api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-analytics-core-api/issues",
-                "source": "https://github.com/liberusoftware/module-analytics-core-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T01:59:03+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/analytics-core-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-analytics-core-filament.git",
-                "reference": "1cbaac1c63a0b45d8daaf2695277177ba1afde31"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-analytics-core-filament/zipball/1cbaac1c63a0b45d8daaf2695277177ba1afde31",
-                "reference": "1cbaac1c63a0b45d8daaf2695277177ba1afde31",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/analytics-core-filament",
+                "reference": "4c7d469cfebb559f65436886e1a941da16360779"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -7358,30 +7364,32 @@
                     "Liberu\\Foundation\\AnalyticsCoreFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\AnalyticsCoreFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Analytics Core filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-analytics-core-filament/issues",
-                "source": "https://github.com/liberusoftware/module-analytics-core-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:05+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/analytics-core-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-analytics-core-livewire.git",
-                "reference": "2be0e7b407d2aa8cedd55e08fbfc08cfa705976d"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-analytics-core-livewire/zipball/2be0e7b407d2aa8cedd55e08fbfc08cfa705976d",
-                "reference": "2be0e7b407d2aa8cedd55e08fbfc08cfa705976d",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/analytics-core-livewire",
+                "reference": "b52c8813f5bfb7821fb8ecbc4aaada2131e4ae01"
             },
             "require": {
                 "liberusoftware/analytics-core": "^1.0",
@@ -7406,16 +7414,24 @@
                     "Liberu\\Foundation\\AnalyticsCoreLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\AnalyticsCoreLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Analytics Core livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-analytics-core-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-analytics-core-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:38+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/analytics-google",
@@ -7468,16 +7484,10 @@
         {
             "name": "liberusoftware/analytics-google-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-analytics-google-api.git",
-                "reference": "00824643236be3c8e360d0154c55cf8377c077cf"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-analytics-google-api/zipball/00824643236be3c8e360d0154c55cf8377c077cf",
-                "reference": "00824643236be3c8e360d0154c55cf8377c077cf",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/analytics-google-api",
+                "reference": "32ff91bae6db616743fb11f0ab7736bf3fa374c6"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -7503,30 +7513,32 @@
                     "Liberu\\Foundation\\AnalyticsGoogleApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\AnalyticsGoogleApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Google Analytics api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-analytics-google-api/issues",
-                "source": "https://github.com/liberusoftware/module-analytics-google-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T01:59:09+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/analytics-google-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-analytics-google-filament.git",
-                "reference": "5df9fbcb76a66a6a999d1b3fb86e54236b2df801"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-analytics-google-filament/zipball/5df9fbcb76a66a6a999d1b3fb86e54236b2df801",
-                "reference": "5df9fbcb76a66a6a999d1b3fb86e54236b2df801",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/analytics-google-filament",
+                "reference": "a26fd6b2401bf59b374f7110278c3ac56e495778"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -7551,30 +7563,32 @@
                     "Liberu\\Foundation\\AnalyticsGoogleFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\AnalyticsGoogleFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Google Analytics filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-analytics-google-filament/issues",
-                "source": "https://github.com/liberusoftware/module-analytics-google-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:09+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/analytics-google-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-analytics-google-livewire.git",
-                "reference": "b026ffdf5530265bf2a806dbdeb62a8770a90650"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-analytics-google-livewire/zipball/b026ffdf5530265bf2a806dbdeb62a8770a90650",
-                "reference": "b026ffdf5530265bf2a806dbdeb62a8770a90650",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/analytics-google-livewire",
+                "reference": "a55e94bc331f0bb3e33427c2e3e391266afacb24"
             },
             "require": {
                 "liberusoftware/analytics-google": "^1.0",
@@ -7599,16 +7613,24 @@
                     "Liberu\\Foundation\\AnalyticsGoogleLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\AnalyticsGoogleLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Google Analytics livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-analytics-google-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-analytics-google-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:42+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/analytics-meta",
@@ -7661,16 +7683,10 @@
         {
             "name": "liberusoftware/analytics-meta-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-analytics-meta-api.git",
-                "reference": "8b2ff83f29165b48588748966a814bc1ed3df04a"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-analytics-meta-api/zipball/8b2ff83f29165b48588748966a814bc1ed3df04a",
-                "reference": "8b2ff83f29165b48588748966a814bc1ed3df04a",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/analytics-meta-api",
+                "reference": "23bec6dbb3d7848a026ee4da2841b9243b3089c1"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -7696,30 +7712,32 @@
                     "Liberu\\Foundation\\AnalyticsMetaApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\AnalyticsMetaApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Meta Server-Side Tracking api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-analytics-meta-api/issues",
-                "source": "https://github.com/liberusoftware/module-analytics-meta-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T01:59:15+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/analytics-meta-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-analytics-meta-filament.git",
-                "reference": "715303a05643b1ddd618bacc2e3d986c2ce93980"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-analytics-meta-filament/zipball/715303a05643b1ddd618bacc2e3d986c2ce93980",
-                "reference": "715303a05643b1ddd618bacc2e3d986c2ce93980",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/analytics-meta-filament",
+                "reference": "14e3be0900ee42d628f5d93f881238e960454282"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -7744,30 +7762,32 @@
                     "Liberu\\Foundation\\AnalyticsMetaFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\AnalyticsMetaFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Meta Server-Side Tracking filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-analytics-meta-filament/issues",
-                "source": "https://github.com/liberusoftware/module-analytics-meta-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:14+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/analytics-meta-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-analytics-meta-livewire.git",
-                "reference": "a72a53522937c1d4da5187dfbf5526e27eab9c8d"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-analytics-meta-livewire/zipball/a72a53522937c1d4da5187dfbf5526e27eab9c8d",
-                "reference": "a72a53522937c1d4da5187dfbf5526e27eab9c8d",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/analytics-meta-livewire",
+                "reference": "d8f1bb1ff275cac072e31cc96057edb2caf3dd42"
             },
             "require": {
                 "liberusoftware/analytics-meta": "^1.0",
@@ -7792,16 +7812,24 @@
                     "Liberu\\Foundation\\AnalyticsMetaLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\AnalyticsMetaLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Meta Server-Side Tracking livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-analytics-meta-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-analytics-meta-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:46+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/api-access",
@@ -7855,16 +7883,10 @@
         {
             "name": "liberusoftware/api-access-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-api-access-api.git",
-                "reference": "9fb23a7213b29bc1225c213aa7b81a59b475313d"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-api-access-api/zipball/9fb23a7213b29bc1225c213aa7b81a59b475313d",
-                "reference": "9fb23a7213b29bc1225c213aa7b81a59b475313d",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/api-access-api",
+                "reference": "6f47abf0542fcec85ba2abfae18e07c75db1d97d"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -7890,30 +7912,32 @@
                     "Liberu\\Foundation\\ApiAccessApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ApiAccessApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "API Access api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-api-access-api/issues",
-                "source": "https://github.com/liberusoftware/module-api-access-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T01:59:21+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/api-access-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-api-access-filament.git",
-                "reference": "0463c677f03178970c607255c8bdab70994cdfc5"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-api-access-filament/zipball/0463c677f03178970c607255c8bdab70994cdfc5",
-                "reference": "0463c677f03178970c607255c8bdab70994cdfc5",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/api-access-filament",
+                "reference": "ac1272f6ab4c1a295b2964c32af80aa7908eacd2"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -7938,30 +7962,32 @@
                     "Liberu\\Foundation\\ApiAccessFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ApiAccessFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "API Access filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-api-access-filament/issues",
-                "source": "https://github.com/liberusoftware/module-api-access-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:18+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/api-access-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-api-access-livewire.git",
-                "reference": "732266fad0c691312d008fec6f0216b8df6774f8"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-api-access-livewire/zipball/732266fad0c691312d008fec6f0216b8df6774f8",
-                "reference": "732266fad0c691312d008fec6f0216b8df6774f8",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/api-access-livewire",
+                "reference": "903e48f71dd6acb41ffe10d0ff103327ada2294e"
             },
             "require": {
                 "liberusoftware/api-access": "^1.0",
@@ -7986,16 +8012,24 @@
                     "Liberu\\Foundation\\ApiAccessLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ApiAccessLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "API Access livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-api-access-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-api-access-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:50+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/application",
@@ -8048,16 +8082,10 @@
         {
             "name": "liberusoftware/application-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-application-api.git",
-                "reference": "2d0b4a4f4031343dab8908769876ddde849f4802"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-application-api/zipball/2d0b4a4f4031343dab8908769876ddde849f4802",
-                "reference": "2d0b4a4f4031343dab8908769876ddde849f4802",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/application-api",
+                "reference": "d084c60905681c17f112a8b32bdc015cda048f27"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -8083,30 +8111,32 @@
                     "Liberu\\Foundation\\ApplicationApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ApplicationApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Application Core api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-application-api/issues",
-                "source": "https://github.com/liberusoftware/module-application-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T01:59:27+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/application-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-application-filament.git",
-                "reference": "92b05033c2584163aaf9321473c4f3cd5bba766b"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-application-filament/zipball/92b05033c2584163aaf9321473c4f3cd5bba766b",
-                "reference": "92b05033c2584163aaf9321473c4f3cd5bba766b",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/application-filament",
+                "reference": "29072ec5ab5fa652bfaa90ba21f90422df40a343"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -8131,30 +8161,32 @@
                     "Liberu\\Foundation\\ApplicationFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ApplicationFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Application Core filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-application-filament/issues",
-                "source": "https://github.com/liberusoftware/module-application-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:23+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/application-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-application-livewire.git",
-                "reference": "f7f799f24f52073f67067932cce0879c44b19331"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-application-livewire/zipball/f7f799f24f52073f67067932cce0879c44b19331",
-                "reference": "f7f799f24f52073f67067932cce0879c44b19331",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/application-livewire",
+                "reference": "2dc58be6999bc0eef32bcdaf48a33648f563a0cc"
             },
             "require": {
                 "liberusoftware/application": "^1.0",
@@ -8179,16 +8211,24 @@
                     "Liberu\\Foundation\\ApplicationLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ApplicationLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Application Core livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-application-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-application-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:54+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/audit",
@@ -8241,16 +8281,10 @@
         {
             "name": "liberusoftware/audit-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-audit-api.git",
-                "reference": "e836e0b68cd71e37fa24916525d9936766696858"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-audit-api/zipball/e836e0b68cd71e37fa24916525d9936766696858",
-                "reference": "e836e0b68cd71e37fa24916525d9936766696858",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/audit-api",
+                "reference": "b339db4a1a112b47277c13ca99e4a4d7712d691c"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -8276,30 +8310,32 @@
                     "Liberu\\Foundation\\AuditApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\AuditApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Audit api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-audit-api/issues",
-                "source": "https://github.com/liberusoftware/module-audit-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T01:59:32+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/audit-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-audit-filament.git",
-                "reference": "52ab9960a30048ff30b35e82afb289ed545131fb"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-audit-filament/zipball/52ab9960a30048ff30b35e82afb289ed545131fb",
-                "reference": "52ab9960a30048ff30b35e82afb289ed545131fb",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/audit-filament",
+                "reference": "f891053a31d5c986fdc97290a583032b52c22d0c"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -8324,30 +8360,32 @@
                     "Liberu\\Foundation\\AuditFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\AuditFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Audit filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-audit-filament/issues",
-                "source": "https://github.com/liberusoftware/module-audit-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:27+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/audit-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-audit-livewire.git",
-                "reference": "3e641619118fc86a60c1d118781896dda45d6649"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-audit-livewire/zipball/3e641619118fc86a60c1d118781896dda45d6649",
-                "reference": "3e641619118fc86a60c1d118781896dda45d6649",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/audit-livewire",
+                "reference": "8041f20fca96497905f6692967d24b7fab3592e8"
             },
             "require": {
                 "liberusoftware/audit": "^1.0",
@@ -8372,16 +8410,24 @@
                     "Liberu\\Foundation\\AuditLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\AuditLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Audit livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-audit-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-audit-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:59+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/composer-installer",
@@ -8478,16 +8524,10 @@
         {
             "name": "liberusoftware/currency-context-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-currency-context-api.git",
-                "reference": "9f4732826d377d780503b9a67138826cc86afea4"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-currency-context-api/zipball/9f4732826d377d780503b9a67138826cc86afea4",
-                "reference": "9f4732826d377d780503b9a67138826cc86afea4",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/currency-context-api",
+                "reference": "6071b03341f9bddf7e057c41ddb0fd7c58b31138"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -8513,30 +8553,32 @@
                     "Liberu\\Foundation\\CurrencyContextApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\CurrencyContextApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Currency Context api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-currency-context-api/issues",
-                "source": "https://github.com/liberusoftware/module-currency-context-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T01:59:38+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/currency-context-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-currency-context-filament.git",
-                "reference": "ce0ac6462de3667e3e8c822b26b09eb087f964f6"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-currency-context-filament/zipball/ce0ac6462de3667e3e8c822b26b09eb087f964f6",
-                "reference": "ce0ac6462de3667e3e8c822b26b09eb087f964f6",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/currency-context-filament",
+                "reference": "9e9e841d34a893d0b4dd37b331c58f4172d96275"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -8561,30 +8603,32 @@
                     "Liberu\\Foundation\\CurrencyContextFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\CurrencyContextFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Currency Context filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-currency-context-filament/issues",
-                "source": "https://github.com/liberusoftware/module-currency-context-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:31+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/currency-context-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-currency-context-livewire.git",
-                "reference": "4d79cf9b695094add3b568ef6adea5811db2ddc9"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-currency-context-livewire/zipball/4d79cf9b695094add3b568ef6adea5811db2ddc9",
-                "reference": "4d79cf9b695094add3b568ef6adea5811db2ddc9",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/currency-context-livewire",
+                "reference": "6a1c8bb57e0e51b675fa9820d21c93c7125f35d1"
             },
             "require": {
                 "liberusoftware/currency-context": "^1.0",
@@ -8609,16 +8653,24 @@
                     "Liberu\\Foundation\\CurrencyContextLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\CurrencyContextLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Currency Context livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-currency-context-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-currency-context-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:08:03+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/developer-experience",
@@ -8671,16 +8723,10 @@
         {
             "name": "liberusoftware/developer-experience-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-developer-experience-api.git",
-                "reference": "0374de51763a017162bf8b2acc933c9a36c4ea82"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-developer-experience-api/zipball/0374de51763a017162bf8b2acc933c9a36c4ea82",
-                "reference": "0374de51763a017162bf8b2acc933c9a36c4ea82",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/developer-experience-api",
+                "reference": "523db888dd2f9c358ae5bfe3c6ee791ca67a7e80"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -8706,30 +8752,32 @@
                     "Liberu\\Foundation\\DeveloperExperienceApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\DeveloperExperienceApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Developer Experience api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-developer-experience-api/issues",
-                "source": "https://github.com/liberusoftware/module-developer-experience-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T01:59:44+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/developer-experience-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-developer-experience-filament.git",
-                "reference": "7e06b4bb4b43985abf60fa5f5e34c6bcd0280cb6"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-developer-experience-filament/zipball/7e06b4bb4b43985abf60fa5f5e34c6bcd0280cb6",
-                "reference": "7e06b4bb4b43985abf60fa5f5e34c6bcd0280cb6",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/developer-experience-filament",
+                "reference": "4cd0035f706e7f17ffd4796eb44d79e8faa45cf7"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -8754,30 +8802,32 @@
                     "Liberu\\Foundation\\DeveloperExperienceFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\DeveloperExperienceFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Developer Experience filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-developer-experience-filament/issues",
-                "source": "https://github.com/liberusoftware/module-developer-experience-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:35+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/developer-experience-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-developer-experience-livewire.git",
-                "reference": "641146d8344b0a8ee8721ea4abc507f28d00f1a4"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-developer-experience-livewire/zipball/641146d8344b0a8ee8721ea4abc507f28d00f1a4",
-                "reference": "641146d8344b0a8ee8721ea4abc507f28d00f1a4",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/developer-experience-livewire",
+                "reference": "89856bd6c0b944b5fca778644062681c1eae55e0"
             },
             "require": {
                 "liberusoftware/developer-experience": "^1.0",
@@ -8802,16 +8852,24 @@
                     "Liberu\\Foundation\\DeveloperExperienceLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\DeveloperExperienceLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Developer Experience livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-developer-experience-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-developer-experience-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:08:07+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/feature-flags",
@@ -8864,16 +8922,10 @@
         {
             "name": "liberusoftware/feature-flags-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-feature-flags-api.git",
-                "reference": "bd9d71c777b096c14c26cab521ada1ef9dbce2aa"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-feature-flags-api/zipball/bd9d71c777b096c14c26cab521ada1ef9dbce2aa",
-                "reference": "bd9d71c777b096c14c26cab521ada1ef9dbce2aa",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/feature-flags-api",
+                "reference": "15a1d00c130b607e6e528bdea8bdda3475f6fb37"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -8899,30 +8951,32 @@
                     "Liberu\\Foundation\\FeatureFlagsApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\FeatureFlagsApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Feature Flags api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-feature-flags-api/issues",
-                "source": "https://github.com/liberusoftware/module-feature-flags-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T01:59:49+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/feature-flags-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-feature-flags-filament.git",
-                "reference": "aa27f9799295ff40f6c0f9e022029bec1ddb2beb"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-feature-flags-filament/zipball/aa27f9799295ff40f6c0f9e022029bec1ddb2beb",
-                "reference": "aa27f9799295ff40f6c0f9e022029bec1ddb2beb",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/feature-flags-filament",
+                "reference": "90a9703935d5888f76798ef10b5e5bc0db42a1da"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -8947,30 +9001,32 @@
                     "Liberu\\Foundation\\FeatureFlagsFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\FeatureFlagsFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Feature Flags filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-feature-flags-filament/issues",
-                "source": "https://github.com/liberusoftware/module-feature-flags-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:39+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/feature-flags-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-feature-flags-livewire.git",
-                "reference": "f804d3f7337cd8cef48249c2c395a0ce18264b9e"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-feature-flags-livewire/zipball/f804d3f7337cd8cef48249c2c395a0ce18264b9e",
-                "reference": "f804d3f7337cd8cef48249c2c395a0ce18264b9e",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/feature-flags-livewire",
+                "reference": "fdd605d99948384ec1eef06824ec669a52dc24b9"
             },
             "require": {
                 "liberusoftware/feature-flags": "^1.0",
@@ -8995,16 +9051,24 @@
                     "Liberu\\Foundation\\FeatureFlagsLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\FeatureFlagsLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Feature Flags livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-feature-flags-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-feature-flags-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:08:11+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/files-media",
@@ -9057,16 +9121,10 @@
         {
             "name": "liberusoftware/files-media-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-files-media-api.git",
-                "reference": "ee06b678d0da7b4691e48c209bbd860c8e60acef"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-files-media-api/zipball/ee06b678d0da7b4691e48c209bbd860c8e60acef",
-                "reference": "ee06b678d0da7b4691e48c209bbd860c8e60acef",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/files-media-api",
+                "reference": "882d009593ee44dd0afa142bed6302f68469e809"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -9092,30 +9150,32 @@
                     "Liberu\\Foundation\\FilesMediaApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\FilesMediaApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Files and Media api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-files-media-api/issues",
-                "source": "https://github.com/liberusoftware/module-files-media-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T01:59:55+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/files-media-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-files-media-filament.git",
-                "reference": "eb5c26f4b8fbbb9dbe8465c4ee41bf01fd62d1ab"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-files-media-filament/zipball/eb5c26f4b8fbbb9dbe8465c4ee41bf01fd62d1ab",
-                "reference": "eb5c26f4b8fbbb9dbe8465c4ee41bf01fd62d1ab",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/files-media-filament",
+                "reference": "75249e8954d7b505fe9f305a66963a0d67f9fa9f"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -9140,30 +9200,32 @@
                     "Liberu\\Foundation\\FilesMediaFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\FilesMediaFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Files and Media filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-files-media-filament/issues",
-                "source": "https://github.com/liberusoftware/module-files-media-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:44+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/files-media-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-files-media-livewire.git",
-                "reference": "b50e1619f2cbb3dc2f0d2b29faede8b595ac5adc"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-files-media-livewire/zipball/b50e1619f2cbb3dc2f0d2b29faede8b595ac5adc",
-                "reference": "b50e1619f2cbb3dc2f0d2b29faede8b595ac5adc",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/files-media-livewire",
+                "reference": "dd6d87dc4292fcbe65310e073726f2169ab63b3c"
             },
             "require": {
                 "liberusoftware/files-media": "^1.0",
@@ -9188,16 +9250,24 @@
                     "Liberu\\Foundation\\FilesMediaLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\FilesMediaLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Files and Media livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-files-media-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-files-media-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:08:15+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/identity-core",
@@ -9297,10 +9367,11 @@
             "dist": {
                 "type": "path",
                 "url": "modules/identity-core-filament",
-                "reference": "6b910864e2ab9451e0c750e2c96fd0cc16107225"
+                "reference": "89cfe59743bb67082f96d70d4be9855ecdffc523"
             },
             "require": {
                 "filament/filament": "^5.1",
+                "liberusoftware/organizations-teams": "^1.0",
                 "liberusoftware/roles-permissions": "^1.0",
                 "php": "^8.5"
             },
@@ -9341,16 +9412,10 @@
         {
             "name": "liberusoftware/identity-core-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-identity-core-livewire.git",
-                "reference": "8a7448b7ed59216021b64e72f8503da44bab9cdc"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-identity-core-livewire/zipball/8a7448b7ed59216021b64e72f8503da44bab9cdc",
-                "reference": "8a7448b7ed59216021b64e72f8503da44bab9cdc",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/identity-core-livewire",
+                "reference": "869c1bf8e18b03afb232b07261f2e3be67c8a5b4"
             },
             "require": {
                 "liberusoftware/identity-core": "^1.0",
@@ -9375,16 +9440,24 @@
                     "Liberu\\Foundation\\IdentityCoreLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\IdentityCoreLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Identity livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-identity-core-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-identity-core-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:08:19+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/identity-socialstream",
@@ -9488,16 +9561,10 @@
         {
             "name": "liberusoftware/import-export-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-import-export-api.git",
-                "reference": "e1df7e484415e03ef520e59af5cf4c16dbab031a"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-import-export-api/zipball/e1df7e484415e03ef520e59af5cf4c16dbab031a",
-                "reference": "e1df7e484415e03ef520e59af5cf4c16dbab031a",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/import-export-api",
+                "reference": "a879b78e6071b216bbae34591600302d103a5775"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -9523,30 +9590,32 @@
                     "Liberu\\Foundation\\ImportExportApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ImportExportApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Import and Export api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-import-export-api/issues",
-                "source": "https://github.com/liberusoftware/module-import-export-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:00:07+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/import-export-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-import-export-filament.git",
-                "reference": "1990cc8fcf98428087201c777c8dd9780173bd72"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-import-export-filament/zipball/1990cc8fcf98428087201c777c8dd9780173bd72",
-                "reference": "1990cc8fcf98428087201c777c8dd9780173bd72",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/import-export-filament",
+                "reference": "a7e42c0e43b944cac6ccf504ff3186a20ab67120"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -9571,30 +9640,32 @@
                     "Liberu\\Foundation\\ImportExportFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ImportExportFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Import and Export filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-import-export-filament/issues",
-                "source": "https://github.com/liberusoftware/module-import-export-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:48+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/import-export-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-import-export-livewire.git",
-                "reference": "84f4a9e07f2fe26d2f14288ee955d5ac493539cc"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-import-export-livewire/zipball/84f4a9e07f2fe26d2f14288ee955d5ac493539cc",
-                "reference": "84f4a9e07f2fe26d2f14288ee955d5ac493539cc",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/import-export-livewire",
+                "reference": "5cf219ab4315cfb42623c4b3679a44febd2015fc"
             },
             "require": {
                 "liberusoftware/import-export": "^1.0",
@@ -9619,16 +9690,24 @@
                     "Liberu\\Foundation\\ImportExportLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ImportExportLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Import and Export livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-import-export-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-import-export-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:08:24+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/integrations",
@@ -9681,16 +9760,10 @@
         {
             "name": "liberusoftware/integrations-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-integrations-api.git",
-                "reference": "34913769d59ef57813fded8a4130e480722f0ea0"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-integrations-api/zipball/34913769d59ef57813fded8a4130e480722f0ea0",
-                "reference": "34913769d59ef57813fded8a4130e480722f0ea0",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/integrations-api",
+                "reference": "9661dfdb7f23b364d0e1a8143ba27c519887c427"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -9716,30 +9789,32 @@
                     "Liberu\\Foundation\\IntegrationsApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\IntegrationsApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Integrations api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-integrations-api/issues",
-                "source": "https://github.com/liberusoftware/module-integrations-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:00:13+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/integrations-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-integrations-filament.git",
-                "reference": "e192188d27420fa3fd144514e6b20bd37746f94b"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-integrations-filament/zipball/e192188d27420fa3fd144514e6b20bd37746f94b",
-                "reference": "e192188d27420fa3fd144514e6b20bd37746f94b",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/integrations-filament",
+                "reference": "bd7422e92922eae96c3e64ba2c4147be3a6aa1df"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -9764,30 +9839,32 @@
                     "Liberu\\Foundation\\IntegrationsFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\IntegrationsFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Integrations filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-integrations-filament/issues",
-                "source": "https://github.com/liberusoftware/module-integrations-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:52+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/integrations-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-integrations-livewire.git",
-                "reference": "7b7273b373736e3b2f543b6f81828eac8e9ba986"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-integrations-livewire/zipball/7b7273b373736e3b2f543b6f81828eac8e9ba986",
-                "reference": "7b7273b373736e3b2f543b6f81828eac8e9ba986",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/integrations-livewire",
+                "reference": "f0dd7c439fdbb8f193b3f66296d32ef9c7478bac"
             },
             "require": {
                 "liberusoftware/integrations": "^1.0",
@@ -9812,16 +9889,24 @@
                     "Liberu\\Foundation\\IntegrationsLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\IntegrationsLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Integrations livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-integrations-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-integrations-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:08:28+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/jetstream-bridge",
@@ -9876,16 +9961,10 @@
         {
             "name": "liberusoftware/jetstream-bridge-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-jetstream-bridge-api.git",
-                "reference": "cb36c3c1889a8c175fe0f5d077c7d6c5ec6417a8"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-jetstream-bridge-api/zipball/cb36c3c1889a8c175fe0f5d077c7d6c5ec6417a8",
-                "reference": "cb36c3c1889a8c175fe0f5d077c7d6c5ec6417a8",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/jetstream-bridge-api",
+                "reference": "35357ff1345330636a87145404b556b8af84c074"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -9911,30 +9990,32 @@
                     "Liberu\\Foundation\\JetstreamBridgeApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\JetstreamBridgeApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Jetstream Bridge api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-jetstream-bridge-api/issues",
-                "source": "https://github.com/liberusoftware/module-jetstream-bridge-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:00:19+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/jetstream-bridge-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-jetstream-bridge-filament.git",
-                "reference": "4aec8c001fb7b6795646ed406fdc9b3d7c55de0a"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-jetstream-bridge-filament/zipball/4aec8c001fb7b6795646ed406fdc9b3d7c55de0a",
-                "reference": "4aec8c001fb7b6795646ed406fdc9b3d7c55de0a",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/jetstream-bridge-filament",
+                "reference": "476062647ac60fc5fd68a75d45623c430eb3eb77"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -9959,30 +10040,32 @@
                     "Liberu\\Foundation\\JetstreamBridgeFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\JetstreamBridgeFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Jetstream Bridge filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-jetstream-bridge-filament/issues",
-                "source": "https://github.com/liberusoftware/module-jetstream-bridge-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:06:56+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/jetstream-bridge-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-jetstream-bridge-livewire.git",
-                "reference": "d99b50bc3283809a187764432e7d76f70296c114"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-jetstream-bridge-livewire/zipball/d99b50bc3283809a187764432e7d76f70296c114",
-                "reference": "d99b50bc3283809a187764432e7d76f70296c114",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/jetstream-bridge-livewire",
+                "reference": "706778646939e37cd6d7e7585fc9a7f93a127468"
             },
             "require": {
                 "liberusoftware/jetstream-bridge": "^1.0",
@@ -10007,16 +10090,24 @@
                     "Liberu\\Foundation\\JetstreamBridgeLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\JetstreamBridgeLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Jetstream Bridge livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-jetstream-bridge-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-jetstream-bridge-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:08:32+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/localization-contracts",
@@ -10106,16 +10197,10 @@
         {
             "name": "liberusoftware/localization-core-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-localization-core-api.git",
-                "reference": "06b940a0b3303ab1a8ed83abaa648aee750bc9c5"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-localization-core-api/zipball/06b940a0b3303ab1a8ed83abaa648aee750bc9c5",
-                "reference": "06b940a0b3303ab1a8ed83abaa648aee750bc9c5",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/localization-core-api",
+                "reference": "3befdcc61eb76de4a368eb843a77bb06f26f0320"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -10141,30 +10226,32 @@
                     "Liberu\\Foundation\\LocalizationCoreApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\LocalizationCoreApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Localization api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-localization-core-api/issues",
-                "source": "https://github.com/liberusoftware/module-localization-core-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:00:24+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/localization-core-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-localization-core-filament.git",
-                "reference": "65e71f4a06c0c1ce5acad4628731e3a8831f7450"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-localization-core-filament/zipball/65e71f4a06c0c1ce5acad4628731e3a8831f7450",
-                "reference": "65e71f4a06c0c1ce5acad4628731e3a8831f7450",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/localization-core-filament",
+                "reference": "6a05bb0e49a2fa5f3cd5f83119ff5cd4827cdc13"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -10189,16 +10276,24 @@
                     "Liberu\\Foundation\\LocalizationCoreFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\LocalizationCoreFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Localization filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-localization-core-filament/issues",
-                "source": "https://github.com/liberusoftware/module-localization-core-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:00+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/localization-core-livewire",
@@ -10348,16 +10443,10 @@
         {
             "name": "liberusoftware/module-manager-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-module-manager-api.git",
-                "reference": "41de80135d2c4289e74100e917ccef9708f1ae24"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-module-manager-api/zipball/41de80135d2c4289e74100e917ccef9708f1ae24",
-                "reference": "41de80135d2c4289e74100e917ccef9708f1ae24",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/module-manager-api",
+                "reference": "b310300b33e5bb2c21ae2f6f069512e236038657"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -10383,16 +10472,24 @@
                     "Liberu\\Foundation\\ModuleManagerApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ModuleManagerApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Module Manager api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-module-manager-api/issues",
-                "source": "https://github.com/liberusoftware/module-module-manager-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:00:30+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/module-manager-filament",
@@ -10445,16 +10542,10 @@
         {
             "name": "liberusoftware/module-manager-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-module-manager-livewire.git",
-                "reference": "9a871f28388e36dc10848115ebee3d963588538c"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-module-manager-livewire/zipball/9a871f28388e36dc10848115ebee3d963588538c",
-                "reference": "9a871f28388e36dc10848115ebee3d963588538c",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/module-manager-livewire",
+                "reference": "0af4954c4c12cd3e0ef754339fb217f34bc02ac2"
             },
             "require": {
                 "liberusoftware/module-manager": "^1.0",
@@ -10479,16 +10570,24 @@
                     "Liberu\\Foundation\\ModuleManagerLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ModuleManagerLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Module Manager livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-module-manager-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-module-manager-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:08:36+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/notifications",
@@ -10541,16 +10640,10 @@
         {
             "name": "liberusoftware/notifications-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-notifications-api.git",
-                "reference": "04e1fdd1bae37e8dae9814129cd129c440f6aeae"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-notifications-api/zipball/04e1fdd1bae37e8dae9814129cd129c440f6aeae",
-                "reference": "04e1fdd1bae37e8dae9814129cd129c440f6aeae",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/notifications-api",
+                "reference": "ccd44be91e1abd46e2d480993638be1709aae8a5"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -10576,30 +10669,32 @@
                     "Liberu\\Foundation\\NotificationsApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\NotificationsApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Notifications api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-notifications-api/issues",
-                "source": "https://github.com/liberusoftware/module-notifications-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:00:35+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/notifications-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-notifications-filament.git",
-                "reference": "98267037def9d05910373f07da661b335de57611"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-notifications-filament/zipball/98267037def9d05910373f07da661b335de57611",
-                "reference": "98267037def9d05910373f07da661b335de57611",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/notifications-filament",
+                "reference": "681091f1e800055a18064738e1cbef034d1e5243"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -10624,30 +10719,32 @@
                     "Liberu\\Foundation\\NotificationsFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\NotificationsFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Notifications filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-notifications-filament/issues",
-                "source": "https://github.com/liberusoftware/module-notifications-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:04+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/notifications-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-notifications-livewire.git",
-                "reference": "1b717e59e9256c0d4e9c12a5115ab6b0674c075d"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-notifications-livewire/zipball/1b717e59e9256c0d4e9c12a5115ab6b0674c075d",
-                "reference": "1b717e59e9256c0d4e9c12a5115ab6b0674c075d",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/notifications-livewire",
+                "reference": "40e0ad7881d2f16723f0caf7a58e9b7959c771bd"
             },
             "require": {
                 "liberusoftware/notifications": "^1.0",
@@ -10672,16 +10769,24 @@
                     "Liberu\\Foundation\\NotificationsLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\NotificationsLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Notifications livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-notifications-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-notifications-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:08:40+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/observability",
@@ -10735,16 +10840,10 @@
         {
             "name": "liberusoftware/observability-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-observability-api.git",
-                "reference": "f0a16509fee317cb68698aa5b91ae91f38761a0c"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-observability-api/zipball/f0a16509fee317cb68698aa5b91ae91f38761a0c",
-                "reference": "f0a16509fee317cb68698aa5b91ae91f38761a0c",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/observability-api",
+                "reference": "1a73a850e8b7294351c2ab554877f6644d237cb1"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -10770,30 +10869,32 @@
                     "Liberu\\Foundation\\ObservabilityApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ObservabilityApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Observability api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-observability-api/issues",
-                "source": "https://github.com/liberusoftware/module-observability-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:00:41+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/observability-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-observability-filament.git",
-                "reference": "53b34927e9f68b3658d8749164fdfe563aedb95d"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-observability-filament/zipball/53b34927e9f68b3658d8749164fdfe563aedb95d",
-                "reference": "53b34927e9f68b3658d8749164fdfe563aedb95d",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/observability-filament",
+                "reference": "abfa43c1bc7899cd03dd646e3ceed4f388b2f722"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -10818,30 +10919,32 @@
                     "Liberu\\Foundation\\ObservabilityFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ObservabilityFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Observability filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-observability-filament/issues",
-                "source": "https://github.com/liberusoftware/module-observability-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:09+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/observability-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-observability-livewire.git",
-                "reference": "b85aa256a432ef919025cfa646439cf485621033"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-observability-livewire/zipball/b85aa256a432ef919025cfa646439cf485621033",
-                "reference": "b85aa256a432ef919025cfa646439cf485621033",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/observability-livewire",
+                "reference": "6a662de722997fb82e40d1d11bc2363cb708b062"
             },
             "require": {
                 "liberusoftware/observability": "^1.0",
@@ -10866,16 +10969,24 @@
                     "Liberu\\Foundation\\ObservabilityLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ObservabilityLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Observability livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-observability-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-observability-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:08:44+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/organizations-teams",
@@ -10929,16 +11040,10 @@
         {
             "name": "liberusoftware/organizations-teams-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-organizations-teams-api.git",
-                "reference": "b3d7125a479ea9386e22f922c487d964d63cfcc3"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-organizations-teams-api/zipball/b3d7125a479ea9386e22f922c487d964d63cfcc3",
-                "reference": "b3d7125a479ea9386e22f922c487d964d63cfcc3",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/organizations-teams-api",
+                "reference": "7f628bac05abfffdc47156fa82313369cd04d214"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -10964,16 +11069,24 @@
                     "Liberu\\Foundation\\OrganizationsTeamsApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\OrganizationsTeamsApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Organizations and Teams api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-organizations-teams-api/issues",
-                "source": "https://github.com/liberusoftware/module-organizations-teams-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:00:46+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/organizations-teams-filament",
@@ -11025,16 +11138,10 @@
         {
             "name": "liberusoftware/organizations-teams-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-organizations-teams-livewire.git",
-                "reference": "27fdd55e915de35edb3014abfd23723a5b3273aa"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-organizations-teams-livewire/zipball/27fdd55e915de35edb3014abfd23723a5b3273aa",
-                "reference": "27fdd55e915de35edb3014abfd23723a5b3273aa",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/organizations-teams-livewire",
+                "reference": "c9aeaf0a514950b509f950a371583e096a54d5d6"
             },
             "require": {
                 "liberusoftware/organizations-teams": "^1.0",
@@ -11059,16 +11166,24 @@
                     "Liberu\\Foundation\\OrganizationsTeamsLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\OrganizationsTeamsLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Organizations and Teams livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-organizations-teams-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-organizations-teams-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:08:49+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/profiles",
@@ -11121,16 +11236,10 @@
         {
             "name": "liberusoftware/profiles-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-profiles-api.git",
-                "reference": "6e995727f49eeaa7ca836603f8ff6c02ed1cb82a"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-profiles-api/zipball/6e995727f49eeaa7ca836603f8ff6c02ed1cb82a",
-                "reference": "6e995727f49eeaa7ca836603f8ff6c02ed1cb82a",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/profiles-api",
+                "reference": "97d6082c91585581b2c937f122c7c922cb9c5fe4"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -11156,30 +11265,32 @@
                     "Liberu\\Foundation\\ProfilesApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ProfilesApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Profiles api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-profiles-api/issues",
-                "source": "https://github.com/liberusoftware/module-profiles-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:00:52+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/profiles-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-profiles-filament.git",
-                "reference": "f89c404a8c14753f984b6808c15f19e904950572"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-profiles-filament/zipball/f89c404a8c14753f984b6808c15f19e904950572",
-                "reference": "f89c404a8c14753f984b6808c15f19e904950572",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/profiles-filament",
+                "reference": "ea543aad585920f83c39049d9c2bd66f991f738f"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -11204,30 +11315,32 @@
                     "Liberu\\Foundation\\ProfilesFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ProfilesFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Profiles filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-profiles-filament/issues",
-                "source": "https://github.com/liberusoftware/module-profiles-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:13+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/profiles-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-profiles-livewire.git",
-                "reference": "3ef74f7e52a8872c3a2163f9b6dd0ed7fbd2f081"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-profiles-livewire/zipball/3ef74f7e52a8872c3a2163f9b6dd0ed7fbd2f081",
-                "reference": "3ef74f7e52a8872c3a2163f9b6dd0ed7fbd2f081",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/profiles-livewire",
+                "reference": "9cb5941d5e3c231aff312f80ca7cebc0730a424b"
             },
             "require": {
                 "liberusoftware/profiles": "^1.0",
@@ -11252,16 +11365,24 @@
                     "Liberu\\Foundation\\ProfilesLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\ProfilesLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Profiles livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-profiles-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-profiles-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:10:14+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/real-estate-core",
@@ -11317,12 +11438,13 @@
             "dist": {
                 "type": "path",
                 "url": "modules/real-estate-core-api",
-                "reference": "72d6099b432185d64d89546a42a36e7bfed56f7c"
+                "reference": "e49a090df36eb593e67431a887c6e17b9e51d17a"
             },
             "require": {
                 "illuminate/http": "^13.0",
                 "illuminate/routing": "^13.0",
                 "liberusoftware/api-access": "^1.0",
+                "liberusoftware/organizations-teams": "^1.0",
                 "liberusoftware/real-estate-core": "^1.0",
                 "php": "^8.5"
             },
@@ -12366,12 +12488,13 @@
             "dist": {
                 "type": "path",
                 "url": "modules/real-estate-media-and-documents-api",
-                "reference": "0c7c1d1d97683a5b931f3032c80622d760e30ef9"
+                "reference": "69249080bc0f949d43620b9986d03d98aa67b989"
             },
             "require": {
                 "illuminate/http": "^13.0",
                 "illuminate/routing": "^13.0",
                 "liberusoftware/real-estate-media-and-documents": "^1.0",
+                "liberusoftware/real-estate-properties": "^1.0",
                 "php": "^8.5"
             },
             "require-dev": {
@@ -13180,11 +13303,13 @@
             "dist": {
                 "type": "path",
                 "url": "modules/real-estate-properties",
-                "reference": "c73ddd5588adfc92e077cdca7ea44ef2e30df239"
+                "reference": "3640c5f1bd2f3413bf7ac71bbbfbac3d623216aa"
             },
             "require": {
                 "illuminate/database": "^13.0",
                 "illuminate/events": "^13.0",
+                "illuminate/http": "^13.0",
+                "illuminate/mail": "^13.0",
                 "illuminate/validation": "^13.0",
                 "liberusoftware/module-manager": "^1.0",
                 "liberusoftware/organizations-teams": "^1.0",
@@ -13230,11 +13355,12 @@
             "dist": {
                 "type": "path",
                 "url": "modules/real-estate-properties-api",
-                "reference": "c611130170e461a8b4262057aac260de6ff90b8b"
+                "reference": "f010e94fb075763e398b3683159525387f36cbf0"
             },
             "require": {
                 "illuminate/http": "^13.0",
                 "illuminate/routing": "^13.0",
+                "liberusoftware/organizations-teams": "^1.0",
                 "liberusoftware/real-estate-properties": "^1.0",
                 "php": "^8.5"
             },
@@ -13890,13 +14016,14 @@
             "dist": {
                 "type": "path",
                 "url": "modules/real-estate-valuations",
-                "reference": "8f16f0c132c77286e94f0adc5c79331eaa221bfd"
+                "reference": "945ea7d2017dc23ec31f8de07f7e82fbc084b2a2"
             },
             "require": {
                 "illuminate/database": "^13.0",
                 "illuminate/validation": "^13.0",
                 "liberusoftware/module-manager": "^1.0",
                 "liberusoftware/organizations-teams": "^1.0",
+                "liberusoftware/real-estate-properties": "^1.0",
                 "php": "^8.5"
             },
             "require-dev": {
@@ -13938,12 +14065,13 @@
             "dist": {
                 "type": "path",
                 "url": "modules/real-estate-valuations-api",
-                "reference": "d3b8e595af111df3c1daf4d82a68094e3691618b"
+                "reference": "49a0a800cd6b054a0557fc07c188fa25f2ab6a0d"
             },
             "require": {
                 "illuminate/http": "^13.0",
                 "illuminate/routing": "^13.0",
                 "liberusoftware/api-access": "^1.0",
+                "liberusoftware/real-estate-properties": "^1.0",
                 "liberusoftware/real-estate-valuations": "^1.0",
                 "php": "^8.5"
             },
@@ -14554,13 +14682,13 @@
             "dist": {
                 "type": "path",
                 "url": "modules/roles-permissions",
-                "reference": "f3a09b8d76ea74a094399a230a4edfbcffdeb42e"
+                "reference": "576f89c61b848ac865037739c15320dd0be824ca"
             },
             "require": {
                 "liberusoftware/module-manager": "^1.0",
                 "liberusoftware/organizations-teams": "^1.0",
                 "php": "^8.5",
-                "spatie/laravel-permission": "^7.0"
+                "spatie/laravel-permission": "^8.0"
             },
             "require-dev": {
                 "liberusoftware/package-testbench": "^1.5",
@@ -14599,16 +14727,10 @@
         {
             "name": "liberusoftware/roles-permissions-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-roles-permissions-api.git",
-                "reference": "7da7f62349593db990425845eee3ebbe2ac3edda"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-roles-permissions-api/zipball/7da7f62349593db990425845eee3ebbe2ac3edda",
-                "reference": "7da7f62349593db990425845eee3ebbe2ac3edda",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/roles-permissions-api",
+                "reference": "b0c60a1e8988f521f7a2e0fc4d434a4aa1d520e8"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -14634,16 +14756,24 @@
                     "Liberu\\Foundation\\RolesPermissionsApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\RolesPermissionsApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Roles and Permissions api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-roles-permissions-api/issues",
-                "source": "https://github.com/liberusoftware/module-roles-permissions-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:00:57+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/roles-permissions-filament",
@@ -14696,16 +14826,10 @@
         {
             "name": "liberusoftware/roles-permissions-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-roles-permissions-livewire.git",
-                "reference": "3d0450a1b183253a0a7bc3d16509e0df7234e4dc"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-roles-permissions-livewire/zipball/3d0450a1b183253a0a7bc3d16509e0df7234e4dc",
-                "reference": "3d0450a1b183253a0a7bc3d16509e0df7234e4dc",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/roles-permissions-livewire",
+                "reference": "a2821a0bd7168bffdfa8556db2f19a417b3a0f96"
             },
             "require": {
                 "liberusoftware/roles-permissions": "^1.0",
@@ -14730,16 +14854,24 @@
                     "Liberu\\Foundation\\RolesPermissionsLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\RolesPermissionsLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Roles and Permissions livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-roles-permissions-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-roles-permissions-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:10:19+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/scheduler-queues",
@@ -14792,16 +14924,10 @@
         {
             "name": "liberusoftware/scheduler-queues-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-scheduler-queues-api.git",
-                "reference": "b57a6fac5829b0a1f8f6bb9766080a73ac272eab"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-scheduler-queues-api/zipball/b57a6fac5829b0a1f8f6bb9766080a73ac272eab",
-                "reference": "b57a6fac5829b0a1f8f6bb9766080a73ac272eab",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/scheduler-queues-api",
+                "reference": "11ee7e43312d1744d5f94bb2fc7e99f532654ff5"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -14827,30 +14953,32 @@
                     "Liberu\\Foundation\\SchedulerQueuesApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\SchedulerQueuesApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Scheduler and Queues api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-scheduler-queues-api/issues",
-                "source": "https://github.com/liberusoftware/module-scheduler-queues-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:01:03+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/scheduler-queues-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-scheduler-queues-filament.git",
-                "reference": "43b2cbbd485133fd2e71e8cf4c60540686c20d5c"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-scheduler-queues-filament/zipball/43b2cbbd485133fd2e71e8cf4c60540686c20d5c",
-                "reference": "43b2cbbd485133fd2e71e8cf4c60540686c20d5c",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/scheduler-queues-filament",
+                "reference": "4a83620537384e5ebeba98248c8fec0449473768"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -14875,30 +15003,32 @@
                     "Liberu\\Foundation\\SchedulerQueuesFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\SchedulerQueuesFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Scheduler and Queues filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-scheduler-queues-filament/issues",
-                "source": "https://github.com/liberusoftware/module-scheduler-queues-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:17+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/scheduler-queues-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-scheduler-queues-livewire.git",
-                "reference": "c08036c33f330b1f70028ee2c5001f20f025df02"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-scheduler-queues-livewire/zipball/c08036c33f330b1f70028ee2c5001f20f025df02",
-                "reference": "c08036c33f330b1f70028ee2c5001f20f025df02",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/scheduler-queues-livewire",
+                "reference": "8f684d7f08d182c93afc777c14539b1f50a2e597"
             },
             "require": {
                 "liberusoftware/scheduler-queues": "^1.0",
@@ -14923,16 +15053,24 @@
                     "Liberu\\Foundation\\SchedulerQueuesLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\SchedulerQueuesLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Scheduler and Queues livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-scheduler-queues-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-scheduler-queues-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:10:23+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/search",
@@ -15034,16 +15172,10 @@
         {
             "name": "liberusoftware/search-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-search-filament.git",
-                "reference": "597764f77d5deaac4e19e13b78415f42eacdb11e"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-search-filament/zipball/597764f77d5deaac4e19e13b78415f42eacdb11e",
-                "reference": "597764f77d5deaac4e19e13b78415f42eacdb11e",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/search-filament",
+                "reference": "7920aef158721077f56b939f7fd2af16f8bc7f5a"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -15068,30 +15200,32 @@
                     "Liberu\\Foundation\\SearchFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\SearchFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Search filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-search-filament/issues",
-                "source": "https://github.com/liberusoftware/module-search-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:22+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/search-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-search-livewire.git",
-                "reference": "f27a6fa1f13ffcb91b9df2e8da7b5e1294a1ad57"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-search-livewire/zipball/f27a6fa1f13ffcb91b9df2e8da7b5e1294a1ad57",
-                "reference": "f27a6fa1f13ffcb91b9df2e8da7b5e1294a1ad57",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/search-livewire",
+                "reference": "3cd6241651e5e8b0d2c1e355114bd6f41eb1f453"
             },
             "require": {
                 "liberusoftware/search": "^1.0",
@@ -15116,16 +15250,24 @@
                     "Liberu\\Foundation\\SearchLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\SearchLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Search livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-search-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-search-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:10:27+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/sessions-devices",
@@ -15178,16 +15320,10 @@
         {
             "name": "liberusoftware/sessions-devices-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-sessions-devices-api.git",
-                "reference": "7177ec966dc754d48f031412647b9cd2579a8d9d"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-sessions-devices-api/zipball/7177ec966dc754d48f031412647b9cd2579a8d9d",
-                "reference": "7177ec966dc754d48f031412647b9cd2579a8d9d",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/sessions-devices-api",
+                "reference": "3ec781d9dd2abb0c20ff23c42bed9fbb59b41962"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -15213,16 +15349,24 @@
                     "Liberu\\Foundation\\SessionsDevicesApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\SessionsDevicesApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Sessions and Devices api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-sessions-devices-api/issues",
-                "source": "https://github.com/liberusoftware/module-sessions-devices-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:01:09+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/sessions-devices-filament",
@@ -15274,16 +15418,10 @@
         {
             "name": "liberusoftware/sessions-devices-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-sessions-devices-livewire.git",
-                "reference": "4365df088271474be0bb2f5dc60c6dc6f144b079"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-sessions-devices-livewire/zipball/4365df088271474be0bb2f5dc60c6dc6f144b079",
-                "reference": "4365df088271474be0bb2f5dc60c6dc6f144b079",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/sessions-devices-livewire",
+                "reference": "8e988a45435b1862e5d154d5918907519e53cd34"
             },
             "require": {
                 "liberusoftware/sessions-devices": "^1.0",
@@ -15308,16 +15446,24 @@
                     "Liberu\\Foundation\\SessionsDevicesLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\SessionsDevicesLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Sessions and Devices livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-sessions-devices-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-sessions-devices-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:10:31+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/settings",
@@ -15369,16 +15515,10 @@
         {
             "name": "liberusoftware/settings-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-settings-api.git",
-                "reference": "563274e3688bc3b2385dd8093693d0a553780aba"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-settings-api/zipball/563274e3688bc3b2385dd8093693d0a553780aba",
-                "reference": "563274e3688bc3b2385dd8093693d0a553780aba",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/settings-api",
+                "reference": "1dd42d9dc75a67195a1a547019fbfd0c0ff48aa4"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -15404,16 +15544,24 @@
                     "Liberu\\Foundation\\SettingsApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\SettingsApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Settings api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-settings-api/issues",
-                "source": "https://github.com/liberusoftware/module-settings-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:01:15+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/settings-filament",
@@ -15469,16 +15617,10 @@
         {
             "name": "liberusoftware/settings-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-settings-livewire.git",
-                "reference": "6fe2730b9bdfb1846765d3b44d8f16109d965b01"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-settings-livewire/zipball/6fe2730b9bdfb1846765d3b44d8f16109d965b01",
-                "reference": "6fe2730b9bdfb1846765d3b44d8f16109d965b01",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/settings-livewire",
+                "reference": "0e19c62616d8353a6aef8e97c298c09ff3a1d391"
             },
             "require": {
                 "liberusoftware/settings": "^1.0",
@@ -15503,16 +15645,24 @@
                     "Liberu\\Foundation\\SettingsLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\SettingsLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Settings livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-settings-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-settings-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:10:36+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/theme-base",
@@ -15650,16 +15800,16 @@
         },
         {
             "name": "liberusoftware/theme-default",
-            "version": "1.5.2",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/theme-default.git",
-                "reference": "5943f51bb86cfef39172cf97b44d9352e101670e"
+                "reference": "a60802aff5e997d2ea4afbec16f7c4387e4dce71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/theme-default/zipball/5943f51bb86cfef39172cf97b44d9352e101670e",
-                "reference": "5943f51bb86cfef39172cf97b44d9352e101670e",
+                "url": "https://api.github.com/repos/liberusoftware/theme-default/zipball/a60802aff5e997d2ea4afbec16f7c4387e4dce71",
+                "reference": "a60802aff5e997d2ea4afbec16f7c4387e4dce71",
                 "shasum": ""
             },
             "require": {
@@ -15689,9 +15839,9 @@
             "description": "Liberu default public theme.",
             "support": {
                 "issues": "https://github.com/liberusoftware/theme-default/issues",
-                "source": "https://github.com/liberusoftware/theme-default/tree/1.5.2"
+                "source": "https://github.com/liberusoftware/theme-default/tree/1.6.0"
             },
-            "time": "2026-08-24T01:26:38+00:00"
+            "time": "2026-09-01T01:52:24+00:00"
         },
         {
             "name": "liberusoftware/theme-real-estate-default",
@@ -15896,16 +16046,10 @@
         {
             "name": "liberusoftware/two-factor-authentication-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-two-factor-authentication-api.git",
-                "reference": "481bae26cf9f1da0648f724970d57aba67d60607"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-two-factor-authentication-api/zipball/481bae26cf9f1da0648f724970d57aba67d60607",
-                "reference": "481bae26cf9f1da0648f724970d57aba67d60607",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/two-factor-authentication-api",
+                "reference": "d32be34fc5c36fb77179f9b631bd1a04f85a0e4c"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -15931,30 +16075,32 @@
                     "Liberu\\Foundation\\TwoFactorAuthenticationApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\TwoFactorAuthenticationApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Two-Factor Authentication api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-two-factor-authentication-api/issues",
-                "source": "https://github.com/liberusoftware/module-two-factor-authentication-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:01:20+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/two-factor-authentication-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-two-factor-authentication-filament.git",
-                "reference": "0f7318c983ff74d9ec61c1b96b498046c421d731"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-two-factor-authentication-filament/zipball/0f7318c983ff74d9ec61c1b96b498046c421d731",
-                "reference": "0f7318c983ff74d9ec61c1b96b498046c421d731",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/two-factor-authentication-filament",
+                "reference": "a3fe15a90f56e3d04515b293a68a0c2c9ace25dc"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -15979,30 +16125,32 @@
                     "Liberu\\Foundation\\TwoFactorAuthenticationFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\TwoFactorAuthenticationFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Two-Factor Authentication filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-two-factor-authentication-filament/issues",
-                "source": "https://github.com/liberusoftware/module-two-factor-authentication-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:26+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/two-factor-authentication-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-two-factor-authentication-livewire.git",
-                "reference": "c82b1317b41d478e18574206ed670f31474106b6"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-two-factor-authentication-livewire/zipball/c82b1317b41d478e18574206ed670f31474106b6",
-                "reference": "c82b1317b41d478e18574206ed670f31474106b6",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/two-factor-authentication-livewire",
+                "reference": "ab8c53f2043d1a8f45684235be4a989957f0f77f"
             },
             "require": {
                 "liberusoftware/two-factor-authentication": "^1.0",
@@ -16027,16 +16175,24 @@
                     "Liberu\\Foundation\\TwoFactorAuthenticationLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\TwoFactorAuthenticationLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Two-Factor Authentication livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-two-factor-authentication-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-two-factor-authentication-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:10:40+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/webhooks",
@@ -16089,16 +16245,10 @@
         {
             "name": "liberusoftware/webhooks-api",
             "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-webhooks-api.git",
-                "reference": "c4bc82f5732dc69a42002418edcbb2146812240d"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-webhooks-api/zipball/c4bc82f5732dc69a42002418edcbb2146812240d",
-                "reference": "c4bc82f5732dc69a42002418edcbb2146812240d",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/webhooks-api",
+                "reference": "f16706dc0f25f82597f2c8040e5ec41ba1f608a3"
             },
             "require": {
                 "illuminate/http": "^13.0",
@@ -16124,30 +16274,32 @@
                     "Liberu\\Foundation\\WebhooksApi\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\WebhooksApi\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Webhooks api presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-webhooks-api/issues",
-                "source": "https://github.com/liberusoftware/module-webhooks-api/tree/1.0.0"
-            },
-            "time": "2026-08-23T02:01:26+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/webhooks-filament",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-webhooks-filament.git",
-                "reference": "eeb49f3acb12dcf094a9fa6b012baf5b810cfe45"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-webhooks-filament/zipball/eeb49f3acb12dcf094a9fa6b012baf5b810cfe45",
-                "reference": "eeb49f3acb12dcf094a9fa6b012baf5b810cfe45",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/webhooks-filament",
+                "reference": "1bdc4e6b0b2615b9a5af1633d1ba17ce52d38982"
             },
             "require": {
                 "filament/filament": "^5.1",
@@ -16172,30 +16324,32 @@
                     "Liberu\\Foundation\\WebhooksFilament\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\WebhooksFilament\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Webhooks filament presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-webhooks-filament/issues",
-                "source": "https://github.com/liberusoftware/module-webhooks-filament/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:07:30+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "liberusoftware/webhooks-livewire",
             "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liberusoftware/module-webhooks-livewire.git",
-                "reference": "fd6d84f6e4d68bd65a2bb2b5361707a6b23d7842"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-webhooks-livewire/zipball/fd6d84f6e4d68bd65a2bb2b5361707a6b23d7842",
-                "reference": "fd6d84f6e4d68bd65a2bb2b5361707a6b23d7842",
-                "shasum": ""
+                "type": "path",
+                "url": "modules/webhooks-livewire",
+                "reference": "1cbcd61da53d34df3e5d41c91ff4a32ce47e0942"
             },
             "require": {
                 "liberusoftware/webhooks": "^1.0",
@@ -16220,29 +16374,37 @@
                     "Liberu\\Foundation\\WebhooksLivewire\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Liberu\\Foundation\\WebhooksLivewire\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "description": "Webhooks livewire presentation adapter.",
-            "support": {
-                "issues": "https://github.com/liberusoftware/module-webhooks-livewire/issues",
-                "source": "https://github.com/liberusoftware/module-webhooks-livewire/tree/1.0.1"
-            },
-            "time": "2026-08-23T02:10:44+00:00"
+            "transport-options": {
+                "symlink": false,
+                "relative": true
+            }
         },
         {
             "name": "livewire/livewire",
-            "version": "v4.4.2",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "4a030935e6c255c89a114b00ece66326f78157c0"
+                "reference": "92f1427022714b34024459167aa6a85d4fb4af44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/4a030935e6c255c89a114b00ece66326f78157c0",
-                "reference": "4a030935e6c255c89a114b00ece66326f78157c0",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/92f1427022714b34024459167aa6a85d4fb4af44",
+                "reference": "92f1427022714b34024459167aa6a85d4fb4af44",
                 "shasum": ""
             },
             "require": {
@@ -16297,7 +16459,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v4.4.2"
+                "source": "https://github.com/livewire/livewire/tree/v4.4.3"
             },
             "funding": [
                 {
@@ -16305,7 +16467,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-24T15:02:06+00:00"
+            "time": "2026-08-31T15:40:58+00:00"
         },
         {
             "name": "mobiledetect/mobiledetectlib",
@@ -16373,16 +16535,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "3.10.0",
+            "version": "3.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
+                "reference": "147f303310f06334f03f409e49d7ad1e275ff05a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
-                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/147f303310f06334f03f409e49d7ad1e275ff05a",
+                "reference": "147f303310f06334f03f409e49d7ad1e275ff05a",
                 "shasum": ""
             },
             "require": {
@@ -16460,7 +16622,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
+                "source": "https://github.com/Seldaek/monolog/tree/3.11.0"
             },
             "funding": [
                 {
@@ -16472,7 +16634,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-02T08:56:05+00:00"
+            "time": "2026-09-02T12:39:56+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -17490,16 +17652,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.3",
+            "version": "2.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
+                "reference": "148cefffaf0233e4c08cc13db8a195a56dd6dfe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
-                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/148cefffaf0233e4c08cc13db8a195a56dd6dfe9",
+                "reference": "148cefffaf0233e4c08cc13db8a195a56dd6dfe9",
                 "shasum": ""
             },
             "require": {
@@ -17531,9 +17693,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.5"
             },
-            "time": "2026-07-08T07:01:06+00:00"
+            "time": "2026-08-31T16:05:28+00:00"
         },
         {
             "name": "pragmarx/google2fa",
@@ -19688,16 +19850,16 @@
         },
         {
             "name": "spatie/laravel-permission",
-            "version": "7.4.2",
+            "version": "8.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-permission.git",
-                "reference": "15a9daf02ba02d3ae77aaa6da582708231ef999b"
+                "reference": "60e8ed5b2fbf043c2264433fc2680c76b8b66aa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/15a9daf02ba02d3ae77aaa6da582708231ef999b",
-                "reference": "15a9daf02ba02d3ae77aaa6da582708231ef999b",
+                "url": "https://api.github.com/repos/spatie/laravel-permission/zipball/60e8ed5b2fbf043c2264433fc2680c76b8b66aa6",
+                "reference": "60e8ed5b2fbf043c2264433fc2680c76b8b66aa6",
                 "shasum": ""
             },
             "require": {
@@ -19710,6 +19872,7 @@
             },
             "require-dev": {
                 "larastan/larastan": "^3.9",
+                "laravel/octane": "^2.0",
                 "laravel/passport": "^13.0",
                 "laravel/pint": "^1.0",
                 "orchestra/testbench": "^10.0|^11.0",
@@ -19725,8 +19888,8 @@
                     ]
                 },
                 "branch-alias": {
-                    "dev-main": "7.x-dev",
-                    "dev-master": "7.x-dev"
+                    "dev-main": "8.x-dev",
+                    "dev-master": "8.x-dev"
                 }
             },
             "autoload": {
@@ -19763,7 +19926,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-permission/issues",
-                "source": "https://github.com/spatie/laravel-permission/tree/7.4.2"
+                "source": "https://github.com/spatie/laravel-permission/tree/8.3.0"
             },
             "funding": [
                 {
@@ -19771,7 +19934,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-30T19:21:26+00:00"
+            "time": "2026-07-03T15:36:01+00:00"
         },
         {
             "name": "spatie/laravel-settings",
@@ -20563,16 +20726,16 @@
         },
         {
             "name": "spiral/roadrunner-http",
-            "version": "v3.6.0",
+            "version": "v4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roadrunner-php/http.git",
-                "reference": "a44a5f7d54d4ee8a14fe99cd22dcd128db270c88"
+                "reference": "b69cf62dcab7d4b1945fef7b40339edd4fc016c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/roadrunner-php/http/zipball/a44a5f7d54d4ee8a14fe99cd22dcd128db270c88",
-                "reference": "a44a5f7d54d4ee8a14fe99cd22dcd128db270c88",
+                "url": "https://api.github.com/repos/roadrunner-php/http/zipball/b69cf62dcab7d4b1945fef7b40339edd4fc016c8",
+                "reference": "b69cf62dcab7d4b1945fef7b40339edd4fc016c8",
                 "shasum": ""
             },
             "require": {
@@ -20641,7 +20804,7 @@
                 "docs": "https://docs.roadrunner.dev",
                 "forum": "https://forum.roadrunner.dev/",
                 "issues": "https://github.com/roadrunner-server/roadrunner/issues",
-                "source": "https://github.com/roadrunner-php/http/tree/v3.6.0"
+                "source": "https://github.com/roadrunner-php/http/tree/v4.1.0"
             },
             "funding": [
                 {
@@ -20649,7 +20812,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-31T12:42:23+00:00"
+            "time": "2026-02-26T11:41:09+00:00"
         },
         {
             "name": "spiral/roadrunner-worker",
@@ -20886,16 +21049,16 @@
         },
         {
             "name": "spomky-labs/cbor-php",
-            "version": "3.3.2",
+            "version": "3.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Spomky-Labs/cbor-php.git",
-                "reference": "3b491dca4bd7e8ae2b14b892cf3c9740f1ba4339"
+                "reference": "1cac24eeae4be47122d505542a170623b2a35ea3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Spomky-Labs/cbor-php/zipball/3b491dca4bd7e8ae2b14b892cf3c9740f1ba4339",
-                "reference": "3b491dca4bd7e8ae2b14b892cf3c9740f1ba4339",
+                "url": "https://api.github.com/repos/Spomky-Labs/cbor-php/zipball/1cac24eeae4be47122d505542a170623b2a35ea3",
+                "reference": "1cac24eeae4be47122d505542a170623b2a35ea3",
                 "shasum": ""
             },
             "require": {
@@ -20941,7 +21104,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Spomky-Labs/cbor-php/issues",
-                "source": "https://github.com/Spomky-Labs/cbor-php/tree/3.3.2"
+                "source": "https://github.com/Spomky-Labs/cbor-php/tree/3.3.4"
             },
             "funding": [
                 {
@@ -20953,7 +21116,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-08-30T13:54:28+00:00"
+            "time": "2026-08-31T18:59:25+00:00"
         },
         {
             "name": "spomky-labs/pki-framework",
@@ -21698,16 +21861,16 @@
         },
         {
             "name": "symfony/html-sanitizer",
-            "version": "v8.1.1",
+            "version": "v8.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/html-sanitizer.git",
-                "reference": "09e1f2f9a3c8dcdca072587dc71999c1921c07cb"
+                "reference": "f8bbdb0704e6b6e9a3412481c1a87886a0633199"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/09e1f2f9a3c8dcdca072587dc71999c1921c07cb",
-                "reference": "09e1f2f9a3c8dcdca072587dc71999c1921c07cb",
+                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/f8bbdb0704e6b6e9a3412481c1a87886a0633199",
+                "reference": "f8bbdb0704e6b6e9a3412481c1a87886a0633199",
                 "shasum": ""
             },
             "require": {
@@ -21746,7 +21909,7 @@
                 "sanitizer"
             ],
             "support": {
-                "source": "https://github.com/symfony/html-sanitizer/tree/v8.1.1"
+                "source": "https://github.com/symfony/html-sanitizer/tree/v8.1.6"
             },
             "funding": [
                 {
@@ -21766,20 +21929,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-06T11:11:44+00:00"
+            "time": "2026-08-30T01:03:44+00:00"
         },
         {
             "name": "symfony/http-client",
-            "version": "v8.1.5",
+            "version": "v8.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "9f941ed000bb11f16dc7eafed98a7b646d3b3e5d"
+                "reference": "fe91dd1ddf09b61aa01e73d29907acbf1775c0a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/9f941ed000bb11f16dc7eafed98a7b646d3b3e5d",
-                "reference": "9f941ed000bb11f16dc7eafed98a7b646d3b3e5d",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/fe91dd1ddf09b61aa01e73d29907acbf1775c0a9",
+                "reference": "fe91dd1ddf09b61aa01e73d29907acbf1775c0a9",
                 "shasum": ""
             },
             "require": {
@@ -21843,7 +22006,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v8.1.5"
+                "source": "https://github.com/symfony/http-client/tree/v8.1.6"
             },
             "funding": [
                 {
@@ -21863,7 +22026,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-21T17:47:34+00:00"
+            "time": "2026-08-30T14:03:40+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -24392,16 +24555,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v8.1.5",
+            "version": "v8.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "b3fc9e8888eeb9daddc33bfbd15d282a61f543cd"
+                "reference": "0b4aa53a67f9fece88c665f1a1dadcfd25d93fe5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/b3fc9e8888eeb9daddc33bfbd15d282a61f543cd",
-                "reference": "b3fc9e8888eeb9daddc33bfbd15d282a61f543cd",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/0b4aa53a67f9fece88c665f1a1dadcfd25d93fe5",
+                "reference": "0b4aa53a67f9fece88c665f1a1dadcfd25d93fe5",
                 "shasum": ""
             },
             "require": {
@@ -24444,7 +24607,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v8.1.5"
+                "source": "https://github.com/symfony/yaml/tree/v8.1.6"
             },
             "funding": [
                 {
@@ -24464,7 +24627,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-21T12:16:08+00:00"
+            "time": "2026-08-30T01:03:44+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -24523,16 +24686,16 @@
         },
         {
             "name": "ueberdosis/tiptap-php",
-            "version": "2.1.2",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ueberdosis/tiptap-php.git",
-                "reference": "0561e2146edbcdc622b5d4008d0ee02582f8642b"
+                "reference": "5a2e8155c5b09c9ad4efd480550270a6924865b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ueberdosis/tiptap-php/zipball/0561e2146edbcdc622b5d4008d0ee02582f8642b",
-                "reference": "0561e2146edbcdc622b5d4008d0ee02582f8642b",
+                "url": "https://api.github.com/repos/ueberdosis/tiptap-php/zipball/5a2e8155c5b09c9ad4efd480550270a6924865b9",
+                "reference": "5a2e8155c5b09c9ad4efd480550270a6924865b9",
                 "shasum": ""
             },
             "require": {
@@ -24572,7 +24735,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ueberdosis/tiptap-php/issues",
-                "source": "https://github.com/ueberdosis/tiptap-php/tree/2.1.2"
+                "source": "https://github.com/ueberdosis/tiptap-php/tree/2.2.0"
             },
             "funding": [
                 {
@@ -24588,7 +24751,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-08-11T08:47:45+00:00"
+            "time": "2026-08-31T07:00:09+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -24821,7 +24984,7 @@
         },
         {
             "name": "web-auth/webauthn-lib",
-            "version": "5.3.7",
+            "version": "5.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-auth/webauthn-lib.git",
@@ -24891,7 +25054,7 @@
                 "webauthn"
             ],
             "support": {
-                "source": "https://github.com/web-auth/webauthn-lib/tree/5.3.7"
+                "source": "https://github.com/web-auth/webauthn-lib/tree/5.3.8"
             },
             "funding": [
                 {
@@ -25192,7 +25355,7 @@
         },
         {
             "name": "filament/upgrade",
-            "version": "v5.7.6",
+            "version": "v5.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/upgrade.git",
@@ -25303,16 +25466,16 @@
         },
         {
             "name": "fruitcake/laravel-debugbar",
-            "version": "v4.4.2",
+            "version": "v4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fruitcake/laravel-debugbar.git",
-                "reference": "18d1c1c64cc5d7794a2c52a2165fe6121e28ed44"
+                "reference": "caa08515a2eef6d8137653d3a1f3c3387cadf184"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruitcake/laravel-debugbar/zipball/18d1c1c64cc5d7794a2c52a2165fe6121e28ed44",
-                "reference": "18d1c1c64cc5d7794a2c52a2165fe6121e28ed44",
+                "url": "https://api.github.com/repos/fruitcake/laravel-debugbar/zipball/caa08515a2eef6d8137653d3a1f3c3387cadf184",
+                "reference": "caa08515a2eef6d8137653d3a1f3c3387cadf184",
                 "shasum": ""
             },
             "require": {
@@ -25390,7 +25553,7 @@
             ],
             "support": {
                 "issues": "https://github.com/fruitcake/laravel-debugbar/issues",
-                "source": "https://github.com/fruitcake/laravel-debugbar/tree/v4.4.2"
+                "source": "https://github.com/fruitcake/laravel-debugbar/tree/v4.4.3"
             },
             "funding": [
                 {
@@ -25402,7 +25565,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-20T12:02:04+00:00"
+            "time": "2026-09-01T13:46:43+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -25562,20 +25725,19 @@
         },
         {
             "name": "larastan/larastan",
-            "version": "v3.10.0",
+            "version": "v3.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/larastan/larastan.git",
-                "reference": "2970f83398154178a739609c244577267c7ee8eb"
+                "reference": "9baa74074f17cc70feaef31616a06ea0faeebba5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/larastan/larastan/zipball/2970f83398154178a739609c244577267c7ee8eb",
-                "reference": "2970f83398154178a739609c244577267c7ee8eb",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/9baa74074f17cc70feaef31616a06ea0faeebba5",
+                "reference": "9baa74074f17cc70feaef31616a06ea0faeebba5",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
                 "iamcal/sql-parser": "^0.7.0",
                 "illuminate/console": "^11.44.2 || ^12.4.1 || ^13",
                 "illuminate/container": "^11.44.2 || ^12.4.1 || ^13",
@@ -25585,7 +25747,7 @@
                 "illuminate/pipeline": "^11.44.2 || ^12.4.1 || ^13",
                 "illuminate/support": "^11.44.2 || ^12.4.1 || ^13",
                 "php": "^8.2",
-                "phpstan/phpstan": "^2.2.0"
+                "phpstan/phpstan": "^2.2.2"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^14",
@@ -25595,7 +25757,7 @@
                 "orchestra/canvas": "^v9.2.2 || ^10.0.1 || ^11",
                 "orchestra/testbench-core": "^9.12.0 || ^10.1 || ^11",
                 "phpstan/phpstan-deprecation-rules": "^2.0.1",
-                "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8 || ^13.1.8"
+                "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8 || ^13.3.0"
             },
             "suggest": {
                 "orchestra/testbench": "Using Larastan for analysing a package needs Testbench",
@@ -25640,7 +25802,7 @@
             ],
             "support": {
                 "issues": "https://github.com/larastan/larastan/issues",
-                "source": "https://github.com/larastan/larastan/tree/v3.10.0"
+                "source": "https://github.com/larastan/larastan/tree/v3.11.0"
             },
             "funding": [
                 {
@@ -25648,7 +25810,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-28T08:00:58+00:00"
+            "time": "2026-09-01T16:35:48+00:00"
         },
         {
             "name": "laravel/boost",
@@ -27025,11 +27187,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.10",
+            "version": "2.2.13",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/36d1509c998b0602811824143526b4a9ee2774e7",
-                "reference": "36d1509c998b0602811824143526b4a9ee2774e7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9ba9ac76ee9c5cf5b56d58eb5deec6315b7a0260",
+                "reference": "9ba9ac76ee9c5cf5b56d58eb5deec6315b7a0260",
                 "shasum": ""
             },
             "require": {
@@ -27085,20 +27247,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-30T12:46:16+00:00"
+            "time": "2026-09-03T20:38:19+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "14.3.1",
+            "version": "14.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6ce313bb110384148d1dc7695a99175f59529069"
+                "reference": "93d62632fb675b76c9b941fdcfcfa10ffb9dea75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6ce313bb110384148d1dc7695a99175f59529069",
-                "reference": "6ce313bb110384148d1dc7695a99175f59529069",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/93d62632fb675b76c9b941fdcfcfa10ffb9dea75",
+                "reference": "93d62632fb675b76c9b941fdcfcfa10ffb9dea75",
                 "shasum": ""
             },
             "require": {
@@ -27117,7 +27279,7 @@
                 "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.3.1"
+                "phpunit/phpunit": "^13.3.2"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -27155,7 +27317,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.3.1"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.3.2"
             },
             "funding": [
                 {
@@ -27175,7 +27337,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-16T05:23:47+00:00"
+            "time": "2026-09-04T03:46:43+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -27564,30 +27726,27 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.6.4",
+            "version": "2.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "6ff008471683591224951526247b7a2b86980ba9"
+                "reference": "ca069d6c79feaa6651b423c15d101a27a436093e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/6ff008471683591224951526247b7a2b86980ba9",
-                "reference": "6ff008471683591224951526247b7a2b86980ba9",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/ca069d6c79feaa6651b423c15d101a27a436093e",
+                "reference": "ca069d6c79feaa6651b423c15d101a27a436093e",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.2.6"
+                "phpstan/phpstan": "^2.2.10"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
                 "rector/rector-downgrade-php": "*",
                 "rector/rector-phpunit": "*",
                 "rector/rector-symfony": "*"
-            },
-            "suggest": {
-                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
             },
             "bin": [
                 "bin/rector"
@@ -27612,7 +27771,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.6.4"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.6"
             },
             "funding": [
                 {
@@ -27620,7 +27779,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-27T09:20:34+00:00"
+            "time": "2026-09-02T09:38:46+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/modules/roles-permissions/composer.json
+++ b/modules/roles-permissions/composer.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "require": {
     "php": "^8.5",
-    "spatie/laravel-permission": "^7.0",
+    "spatie/laravel-permission": "^8.0",
     "liberusoftware/module-manager": "^1.0",
     "liberusoftware/organizations-teams": "^1.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
                 "leaflet": "^1.9.4"
             },
             "devDependencies": {
-                "@laravel/vite-plugin-wayfinder": "^0.1.7",
+                "@laravel/vite-plugin-wayfinder": "^0.1.10",
                 "@tailwindcss/vite": "^4.0.0",
-                "concurrently": "^9.0.1",
-                "laravel-vite-plugin": "^3.1",
+                "concurrently": "^10.0.5",
+                "laravel-vite-plugin": "^3.2",
                 "tailwindcss": "^4.0.0",
                 "vite": "^8.0.0"
             }
@@ -101,9 +101,9 @@
             }
         },
         "node_modules/@laravel/vite-plugin-wayfinder": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/@laravel/vite-plugin-wayfinder/-/vite-plugin-wayfinder-0.1.7.tgz",
-            "integrity": "sha512-yZYIr1iwuCQ7LFI+GsJk9vacw1HWMp3ZlDlW0pdfz3zXyKeu4US7oH79KmQQ031L0cYaSyaUMo/Ha1D4BosKqw==",
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/@laravel/vite-plugin-wayfinder/-/vite-plugin-wayfinder-0.1.10.tgz",
+            "integrity": "sha512-59ZCMCEeC1UcZkqbvn+G06C4D0C/jCm525gTft7T7RPAo+0ZaHtoKl9r86OFVFd/BwuJiOYky4zJUrAPRKyRaA==",
             "dev": true,
             "license": "MIT"
         },
@@ -714,116 +714,79 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+            "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
         "node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
             "engines": {
-                "node": ">=10"
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/chalk/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+            "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
+                "string-width": "^7.2.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=20"
             }
-        },
-        "node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/concurrently": {
-            "version": "9.2.4",
-            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
-            "integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
+            "version": "10.0.5",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.5.tgz",
+            "integrity": "sha512-JaP/CoftUrCcAFW/g//RbgEGwlelnEae6cfBLgH6ZdO6s8jPkn6p9SB9u6pdVxYXoiSnFqseOlHfrEfF82TVOg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "chalk": "4.1.2",
+                "chalk": "5.6.2",
                 "rxjs": "7.8.2",
                 "shell-quote": "1.9.0",
-                "supports-color": "8.1.1",
+                "supports-color": "10.2.2",
                 "tree-kill": "1.2.2",
-                "yargs": "17.7.2"
+                "yargs": "18.0.0"
             },
             "bin": {
-                "conc": "dist/bin/concurrently.js",
-                "concurrently": "dist/bin/concurrently.js"
+                "conc": "dist/bin/index.js",
+                "concurrently": "dist/bin/index.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=22"
             },
             "funding": {
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
@@ -840,9 +803,9 @@
             }
         },
         "node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
             "dev": true,
             "license": "MIT"
         },
@@ -913,32 +876,25 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
+        "node_modules/get-east-asian-width": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/jiti": {
             "version": "2.7.0",
@@ -951,9 +907,9 @@
             }
         },
         "node_modules/laravel-vite-plugin": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-3.1.3.tgz",
-            "integrity": "sha512-cI5Anw4QHY+UzvZczFaj+j8NhwT2FtyEN8aqS/hOdt6DpEFBsn6x3GENxALem3cc+TsGvd9MacneimEvShvKMA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-3.2.0.tgz",
+            "integrity": "sha512-xSxY9Gzeb/eancd8WeK09piAFP+a6i5QIBqNCKNv9L0Eq6wziwzSem7F1GvMSrtjMh5F/QVKFxn8t9naGOA66A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1334,16 +1290,6 @@
                 "node": "^10 || ^12 || >=14"
             }
         },
-        "node_modules/require-directory": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/rolldown": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
@@ -1412,44 +1358,47 @@
             }
         },
         "node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^5.0.1"
+                "ansi-regex": "^6.2.2"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/supports-color": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+            "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
@@ -1613,18 +1562,18 @@
             }
         },
         "node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -1641,32 +1590,31 @@
             }
         },
         "node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "cliui": "^8.0.1",
+                "cliui": "^9.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
+                "string-width": "^7.2.0",
                 "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
+                "yargs-parser": "^22.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
         "node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
             "dev": true,
             "license": "ISC",
             "engines": {
-                "node": ">=12"
+                "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
         "dev": "vite"
     },
     "devDependencies": {
-        "@laravel/vite-plugin-wayfinder": "^0.1.7",
+        "@laravel/vite-plugin-wayfinder": "^0.1.10",
         "@tailwindcss/vite": "^4.0.0",
-        "concurrently": "^9.0.1",
-        "laravel-vite-plugin": "^3.1",
+        "concurrently": "^10.0.5",
+        "laravel-vite-plugin": "^3.2",
         "tailwindcss": "^4.0.0",
         "vite": "^8.0.0"
     },


### PR DESCRIPTION
## Summary\n- update Filament, Laravel, Livewire, Laravel Socialite, Telescope, Larastan, Debugbar and PHPUnit\n- upgrade Spatie Permission to 8.3 and RoadRunner HTTP to 4.1, including the local module constraint\n- refresh npm dependencies and lockfile\n\n## Validation\n- composer validate --strict\n- composer audit\n- composer check-platform-reqs\n- php artisan test tests/Feature/RealEstateDocumentTemplatesTest.php (3 passed, 42 assertions)\n\nThe full suite did not finish in the local environment; existing CI install checks also report tracked generated-module drift.